### PR TITLE
Enhancement: Add support for RSA encryption key imports in JavaKeystoreKeyProvider (#29852)

### DIFF
--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
@@ -93,7 +93,8 @@ public class JavaKeystoreKeyProvider implements KeyProvider {
             String keyAlias = model.get(JavaKeystoreKeyProviderFactory.KEY_ALIAS_KEY);
 
             return switch (algorithm) {
-                case Algorithm.PS256, Algorithm.PS384, Algorithm.PS512, Algorithm.RS256, Algorithm.RS384, Algorithm.RS512 ->
+                case Algorithm.PS256, Algorithm.PS384, Algorithm.PS512, Algorithm.RS256, Algorithm.RS384, Algorithm.RS512,
+                        Algorithm.RSA_OAEP, Algorithm.RSA1_5, Algorithm.RSA_OAEP_256 ->
                         loadRSAKey(realm, model, keyStore, keyAlias);
                 case Algorithm.ES256, Algorithm.ES384, Algorithm.ES512 -> loadECKey(realm, model, keyStore, keyAlias);
                 default ->


### PR DESCRIPTION
Adds functionality to the JavaKeystoreKeyProvider to allow for the import of RSA keys specifically designated for encryption purposes. This enhancement expands the key management capabilities of Keycloak.
