### PR TITLE
Add a media type to error responses on OID4VC endpoints

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -489,7 +489,11 @@ public class OID4VCIssuerEndpoint {
     private Response getErrorResponse(ErrorType errorType) {
         var errorResponse = new ErrorResponse();
         errorResponse.setError(errorType);
-        return Response.status(Response.Status.BAD_REQUEST).entity(errorResponse).build();
+        return Response
+                .status(Response.Status.BAD_REQUEST)
+                .entity(errorResponse)
+                .type(MediaType.APPLICATION_JSON)
+                .build();
     }
 
     // Return all {@link  OID4VCClient}s that support the given scope and format


### PR DESCRIPTION
On issue https://github.com/adorsys/keycloak-ssi-deployment/issues/54, there appeared to be a logic to return a 400 status on expired tokens. The only thing that made the server to fail internally and return 500 was a missing media type on error responses. 

The change is so tiny that I think it can be added to this branch under review at Keycloak. Do you find it appropriate?