### PR TITLE
Implement multiple credential issuance 

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -38,8 +38,6 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.OAuth2Constants;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.SecretGenerator;
-import org.keycloak.component.ComponentFactory;
-import org.keycloak.component.ComponentModel;
 import org.keycloak.constants.Oid4VciConstants;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
@@ -405,6 +403,7 @@ public class OID4VCIssuerEndpoint {
 
         cors = Cors.builder().auth().allowedMethods("POST").auth().exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS);
 
+
         // Authenticate first to fail fast on auth errors
         AuthenticationManager.AuthResult authResult = getAuthResult();
 
@@ -477,13 +476,26 @@ public class OID4VCIssuerEndpoint {
         SupportedCredentialConfiguration supportedCredential =
                 OID4VCIssuerWellKnownProvider.toSupportedCredentialConfiguration(session, requestedCredential);
 
-        Object theCredential = getCredential(authResult, supportedCredential, credentialRequestVO);
+        // Get the list of all proofs (handles single proof, multiple proofs, or none)
+        List<String> allProofs = getAllProofs(credentialRequestVO);
 
-        // Generate credential response
         CredentialResponse responseVO = new CredentialResponse();
-        responseVO
-                .addCredential(theCredential)
-                .setNotificationId(generateNotificationId());
+        responseVO.setNotificationId(generateNotificationId());
+
+        if (allProofs.isEmpty()) {
+            // Single issuance without proof
+            Object theCredential = getCredential(authResult, supportedCredential, credentialRequestVO);
+            responseVO.addCredential(theCredential);
+        } else {
+            // Issue credentials for each proof (or one if no proofs)
+            Proofs originalProofs = credentialRequestVO.getProofs();
+            for (String currentProof : allProofs) {
+                credentialRequestVO.setProofs(new Proofs().setJwt(List.of(currentProof)));
+                Object theCredential = getCredential(authResult, supportedCredential, credentialRequestVO);
+                responseVO.addCredential(theCredential);
+            }
+            credentialRequestVO.setProofs(originalProofs);
+        }
 
         if (encryptionParams != null) {
             String jwe = encryptCredentialResponse(responseVO, encryptionParams);
@@ -494,6 +506,28 @@ public class OID4VCIssuerEndpoint {
         }
 
         return Response.ok().entity(responseVO).build();
+    }
+
+    private List<String> getAllProofs(CredentialRequest credentialRequestVO) {
+        List<String> allProofs = new ArrayList<>();
+        Proofs proofs = credentialRequestVO.getProofs();
+        if (proofs == null) {
+            return allProofs; // No proofs provided
+        }
+
+        int typeCount = 0;
+        if (proofs.getJwt() != null && !proofs.getJwt().isEmpty()) {
+            typeCount++;
+            for (String jwtStr : proofs.getJwt()) {
+                allProofs.add(jwtStr);
+            }
+        }
+        if (typeCount != 1) {
+            throw new BadRequestException(getErrorResponse(ErrorType.INVALID_PROOF,
+                    "The 'proofs' object must contain exactly one proof type with non-empty array."));
+        }
+
+        return allProofs;
     }
 
     /**
@@ -688,7 +722,8 @@ public class OID4VCIssuerEndpoint {
      */
     private Object getCredential(AuthenticationManager.AuthResult authResult,
                                  SupportedCredentialConfiguration credentialConfig,
-                                 CredentialRequest credentialRequestVO) {
+                                 CredentialRequest credentialRequestVO
+    ) {
 
         // Get the client scope model from the credential configuration
         CredentialScopeModel credentialScopeModel = getClientScopeModel(credentialConfig);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -510,23 +510,18 @@ public class OID4VCIssuerEndpoint {
 
     private List<String> getAllProofs(CredentialRequest credentialRequestVO) {
         List<String> allProofs = new ArrayList<>();
+
         Proofs proofs = credentialRequestVO.getProofs();
         if (proofs == null) {
             return allProofs; // No proofs provided
         }
 
-        int typeCount = 0;
-        if (proofs.getJwt() != null && !proofs.getJwt().isEmpty()) {
-            typeCount++;
-            for (String jwtStr : proofs.getJwt()) {
-                allProofs.add(jwtStr);
-            }
-        }
-        if (typeCount != 1) {
+        if (proofs.getJwt() == null || proofs.getJwt().isEmpty()) {
             throw new BadRequestException(getErrorResponse(ErrorType.INVALID_PROOF,
                     "The 'proofs' object must contain exactly one proof type with non-empty array."));
         }
 
+        allProofs.addAll(proofs.getJwt());
         return allProofs;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -77,7 +77,6 @@ import java.security.PrivateKey;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -40,7 +40,6 @@ import org.keycloak.jose.jwe.JWEException;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKParser;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
@@ -59,6 +58,7 @@ import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.OfferUriType;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedGrant;
+import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
@@ -71,11 +71,13 @@ import org.keycloak.util.JsonSerialization;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -91,7 +93,6 @@ import static org.junit.Assert.fail;
  * Test from org.keycloak.testsuite.oid4vc.issuance.signing.OID4VCIssuerEndpointTest
  */
 public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
-
     // ----- getCredentialOfferUri
 
     @Test(expected = BadRequestException.class)
@@ -891,6 +892,81 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             assertEquals("The second credential request should be successful.", 200, response2.getStatus());
             CredentialResponse credentialResponse2 = JsonSerialization.mapper.convertValue(response2.getEntity(), CredentialResponse.class);
             assertNotEquals("Notification IDs should be unique", credentialResponse1.getNotificationId(), credentialResponse2.getNotificationId());
+        });
+    }
+
+    /**
+     * This is testing the multiple credential issuance flow in a single call with proofs
+     */
+    @Test
+    public void testRequestMultipleCredentialsWithProofs() {
+        final String scopeName = jwtTypeCredentialClientScope.getName();
+        String token = getBearerToken(oauth, client, scopeName);
+        String cNonce = getCNonce();
+
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                authenticator.setTokenString(token);
+                String issuer = OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
+
+                String jwtProof1 = generateJwtProof(issuer, cNonce);
+                String jwtProof2 = generateJwtProof(issuer, cNonce);
+                Proofs proofs = new Proofs().setJwt(Arrays.asList(jwtProof1, jwtProof2));
+
+
+                CredentialRequest request = new CredentialRequest()
+                        .setFormat(Format.JWT_VC)
+                        .setCredentialIdentifier(scopeName)
+                        .setProofs(proofs);
+
+                OID4VCIssuerEndpoint endpoint = prepareIssuerEndpoint(session, authenticator);
+
+                Response response = endpoint.requestCredential(request);
+                assertEquals("Response status should be OK", Response.Status.OK.getStatusCode(), response.getStatus());
+
+                CredentialResponse credentialResponse = JsonSerialization.mapper
+                        .convertValue(response.getEntity(), CredentialResponse.class);
+                assertNotNull("Credential response should not be null", credentialResponse);
+                assertNotNull("Credentials array should not be null", credentialResponse.getCredentials());
+                assertEquals("Should return 2 credentials due to two proofs", 2, credentialResponse.getCredentials().size());
+
+                // Validate each credential
+                for (CredentialResponse.Credential credential : credentialResponse.getCredentials()) {
+                    assertNotNull("Credential should not be null", credential.getCredential());
+                    JsonWebToken jsonWebToken;
+                    try {
+                        jsonWebToken = TokenVerifier.create((String) credential.getCredential(), JsonWebToken.class).getToken();
+                    } catch (VerificationException e) {
+                        Assert.fail("Failed to verify JWT: " + e.getMessage());
+                        return;
+                    }
+                    assertNotNull("A valid credential string should be returned", jsonWebToken);
+                    assertNotNull("The credentials should include the vc claim", jsonWebToken.getOtherClaims().get("vc"));
+
+                    VerifiableCredential vc = JsonSerialization.mapper.convertValue(
+                            jsonWebToken.getOtherClaims().get("vc"), VerifiableCredential.class);
+                    assertTrue("The scope-name claim should be set",
+                            vc.getCredentialSubject().getClaims().containsKey("scope-name"));
+                    assertEquals("The scope-name claim should match the scope",
+                            scopeName, vc.getCredentialSubject().getClaims().get("scope-name"));
+                    assertTrue("The given_name claim should be set",
+                            vc.getCredentialSubject().getClaims().containsKey("given_name"));
+                    assertEquals("The given_name claim should be John",
+                            "John", vc.getCredentialSubject().getClaims().get("given_name"));
+                    assertTrue("The email claim should be set",
+                            vc.getCredentialSubject().getClaims().containsKey("email"));
+                    assertEquals("The email claim should be john@email.cz",
+                            "john@email.cz", vc.getCredentialSubject().getClaims().get("email"));
+                    assertFalse("Only supported mappers should be evaluated",
+                            vc.getCredentialSubject().getClaims().containsKey("AnotherCredentialType"));
+
+                }
+
+                assertNotNull("Notification ID should be present", credentialResponse.getNotificationId());
+            } catch (Exception e) {
+                throw new RuntimeException("Test failed due to: " + e.getMessage(), e);
+            }
         });
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
@@ -66,6 +66,7 @@ import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.JsonSerialization;
+import org.testcontainers.shaded.org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -99,7 +100,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                 .server(TEST_REALM_NAME)
                 .run(session -> {
                     ClientScopeRepresentation clientScope = fromJsonString(clientScopeString,
-                                                                           ClientScopeRepresentation.class);
+                            ClientScopeRepresentation.class);
                     testRequestTestCredential(session, clientScope, token, null);
                 });
     }
@@ -118,7 +119,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                             .setJwt(List.of(generateJwtProof(getCredentialIssuer(session), cNonce)));
 
                     ClientScopeRepresentation clientScope = fromJsonString(clientScopeString,
-                                                                           ClientScopeRepresentation.class);
+                            ClientScopeRepresentation.class);
 
                     SdJwtVP sdJwtVP = testRequestTestCredential(session, clientScope, token, proof);
                     assertNotNull("A cnf claim must be attached to the credential", sdJwtVP.getCnfClaim());
@@ -139,7 +140,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                             .setJwt(List.of(generateInvalidJwtProof(getCredentialIssuer(session), cNonce)));
 
                     ClientScopeRepresentation clientScope = fromJsonString(clientScopeString,
-                                                                           ClientScopeRepresentation.class);
+                            ClientScopeRepresentation.class);
 
                     testRequestTestCredential(session, clientScope, token, proof);
                 }));
@@ -173,6 +174,11 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     })));
             Assert.fail("Should have thrown an exception");
         } catch (BadRequestException ex) {
+            Assert.assertEquals("""
+                                        c_nonce: expected 'aud' to be equal to \
+                                        '[https://localhost:8543/auth/realms/test/protocol/oid4vc/credential]' but \
+                                        actual value was '[]'""",
+                    ExceptionUtils.getRootCause(ex).getMessage());
             Assert.assertEquals("Could not validate provided proof", ex.getMessage());
         }
     }
@@ -199,6 +205,11 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     })));
             Assert.fail("Should have thrown an exception");
         } catch (BadRequestException ex) {
+            Assert.assertEquals("""
+                                        c_nonce: expected 'source_endpoint' to be equal to \
+                                        'https://localhost:8543/auth/realms/test/protocol/oid4vc/nonce' but \
+                                        actual value was 'null'""",
+                    ExceptionUtils.getRootCause(ex).getMessage());
             Assert.assertEquals("Could not validate provided proof", ex.getMessage());
         }
     }
@@ -233,6 +244,9 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     })));
             Assert.fail("Should have thrown an exception");
         } catch (BadRequestException ex) {
+            String message = ExceptionUtils.getRootCause(ex).getMessage();
+            Assert.assertTrue(String.format("Message '%s' should match regular expression", message),
+                    message.matches("c_nonce not valid: \\d+\\(exp\\) < \\d+\\(now\\)"));
             Assert.assertEquals("Could not validate provided proof", ex.getMessage());
         }
     }
@@ -256,13 +270,13 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
 
         Response credentialResponse = issuerEndpoint.requestCredential(credentialRequest);
         assertEquals("The credential request should be answered successfully.",
-                     HttpStatus.SC_OK,
-                     credentialResponse.getStatus());
+                HttpStatus.SC_OK,
+                credentialResponse.getStatus());
         assertNotNull("A credential should be responded.", credentialResponse.getEntity());
         CredentialResponse credentialResponseVO = JsonSerialization.mapper.convertValue(credentialResponse.getEntity(),
-                                                                                        CredentialResponse.class);
+                CredentialResponse.class);
         new TestCredentialResponseHandler(sdJwtCredentialVct).handleCredentialResponse(credentialResponseVO,
-                                                                                       clientScope);
+                clientScope);
 
         // Get the credential from the credentials array
         return SdJwtVP.of(credentialResponseVO.getCredentials().get(0).getCredential().toString());
@@ -284,8 +298,8 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
         // 1. Retrieving the credential-offer-uri
         final String credentialConfigurationId = clientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         HttpGet getCredentialOfferURI = new HttpGet(getBasePath(TEST_REALM_NAME) +
-                                                            "credential-offer-uri?credential_configuration_id=" +
-                                                            credentialConfigurationId);
+                "credential-offer-uri?credential_configuration_id=" +
+                credentialConfigurationId);
         getCredentialOfferURI.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
         CloseableHttpResponse credentialOfferURIResponse = httpClient.execute(getCredentialOfferURI);
 
@@ -340,10 +354,10 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                 .forEach(supportedCredential -> {
                     try {
                         requestCredential(theToken,
-                                          credentialIssuer.getCredentialEndpoint(),
-                                          supportedCredential,
-                                          new TestCredentialResponseHandler(vct),
-                                          sdJwtTypeCredentialClientScope);
+                                credentialIssuer.getCredentialEndpoint(),
+                                supportedCredential,
+                                new TestCredentialResponseHandler(vct),
+                                sdJwtTypeCredentialClientScope);
                     } catch (IOException e) {
                         fail("Was not able to get the credential.");
                     } catch (VerificationException e) {
@@ -359,9 +373,9 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
     public void testGetSdJwtConfigFromMetadata() {
         final String scopeName = sdJwtTypeCredentialClientScope.getName();
         final String credentialConfigurationId = sdJwtTypeCredentialClientScope.getAttributes()
-                                                                               .get(CredentialScopeModel.CONFIGURATION_ID);
+                .get(CredentialScopeModel.CONFIGURATION_ID);
         final String verifiableCredentialType = sdJwtTypeCredentialClientScope.getAttributes()
-                                                                              .get(CredentialScopeModel.VCT);
+                .get(CredentialScopeModel.VCT);
         String expectedIssuer = suiteContext.getAuthServerInfo().getContextRoot().toString() + "/auth/realms/" + TEST_REALM_NAME;
         String expectedCredentialsEndpoint = expectedIssuer + "/protocol/oid4vc/credential";
         String expectedNonceEndpoint = expectedIssuer + "/protocol/oid4vc/" + OID4VCIssuerEndpoint.NONCE_PATH;
@@ -376,22 +390,22 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                     assertEquals("The correct issuer should be included.", expectedIssuer, credentialIssuer.getCredentialIssuer());
                     assertEquals("The correct credentials endpoint should be included.", expectedCredentialsEndpoint, credentialIssuer.getCredentialEndpoint());
                     assertEquals("The correct nonce endpoint should be included.",
-                                 expectedNonceEndpoint,
-                                 credentialIssuer.getNonceEndpoint());
+                            expectedNonceEndpoint,
+                            credentialIssuer.getNonceEndpoint());
                     assertEquals("Since the authorization server is equal to the issuer, just 1 should be returned.", 1, credentialIssuer.getAuthorizationServers().size());
                     assertEquals("The expected server should have been returned.", expectedAuthorizationServer, credentialIssuer.getAuthorizationServers().get(0));
 
                     assertTrue("The sd-jwt-credential should be supported.",
-                               credentialIssuer.getCredentialsSupported().containsKey(credentialConfigurationId));
+                            credentialIssuer.getCredentialsSupported().containsKey(credentialConfigurationId));
 
                     SupportedCredentialConfiguration jwtVcConfig =
                             credentialIssuer.getCredentialsSupported().get(credentialConfigurationId);
                     assertEquals("The sd-jwt-credential should offer type test-credential",
-                                 scopeName,
-                                 jwtVcConfig.getScope());
+                            scopeName,
+                            jwtVcConfig.getScope());
                     assertEquals("The sd-jwt-credential should be offered in the jwt_vc format.",
-                                 Format.SD_JWT_VC,
-                                 jwtVcConfig.getFormat());
+                            Format.SD_JWT_VC,
+                            jwtVcConfig.getFormat());
 
                     assertNotNull("The sd-jwt-credential can optionally provide a claims claim.",
                                   credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
@@ -401,80 +415,80 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
 
                     Claims jwtVcClaims = jwtVcConfig.getCredentialMetadata() != null ? jwtVcConfig.getCredentialMetadata().getClaims() : null;
                     assertNotNull("The sd-jwt-credential can optionally provide a claims claim.",
-                                  jwtVcClaims);
+                            jwtVcClaims);
 
                     assertEquals(5,  jwtVcClaims.size());
                     {
                         Claim claim = jwtVcClaims.get(0);
                         assertEquals("The sd-jwt-credential claim roles is present.",
-                                     "roles",
-                                     claim.getPath().get(0));
+                                "roles",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim roles is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim roles has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(1);
                         assertEquals("The sd-jwt-credential claim email is present.",
-                                     "email",
-                                     claim.getPath().get(0));
+                                "email",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim email is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim email has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(2);
                         assertEquals("The sd-jwt-credential claim firstName is present.",
-                                     "firstName",
-                                     claim.getPath().get(0));
+                                "firstName",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim firstName is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim firstName has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(3);
                         assertEquals("The sd-jwt-credential claim lastName is present.",
-                                     "lastName",
-                                     claim.getPath().get(0));
+                                "lastName",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim lastName is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim lastName has no display configured",
-                                      claim.getDisplay());
+                                claim.getDisplay());
                     }
                     {
                         Claim claim = jwtVcClaims.get(4);
                         assertEquals("The sd-jwt-credential claim scope-name is present.",
-                                     "scope-name",
-                                     claim.getPath().get(0));
+                                "scope-name",
+                                claim.getPath().get(0));
                         assertFalse("The sd-jwt-credential claim scope-name is not mandatory.",
-                                    claim.isMandatory());
+                                claim.isMandatory());
                         assertNull("The sd-jwt-credential claim scope-name has no display configured",
-                                   claim.getDisplay());
+                                claim.getDisplay());
                     }
 
                     assertEquals("The sd-jwt-credential should offer vct",
-                                 verifiableCredentialType,
-                                 credentialIssuer.getCredentialsSupported().get(credentialConfigurationId).getVct());
+                            verifiableCredentialType,
+                            credentialIssuer.getCredentialsSupported().get(credentialConfigurationId).getVct());
 
                     // We are offering key binding only for identity credential
                     assertTrue("The sd-jwt-credential should contain a cryptographic binding method supported named jwk",
-                               credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
-                                               .getCryptographicBindingMethodsSupported()
-                                               .contains(CredentialScopeModel.CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT));
+                            credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
+                                    .getCryptographicBindingMethodsSupported()
+                                    .contains(CredentialScopeModel.CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT));
                     assertTrue("The sd-jwt-credential should contain a credential signing algorithm named ES256",
-                               credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
-                                               .getCredentialSigningAlgValuesSupported().contains("ES256"));
+                            credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
+                                    .getCredentialSigningAlgValuesSupported().contains("ES256"));
                     assertTrue("The sd-jwt-credential should support a proof of type jwt with signing algorithm ES256",
-                               credentialIssuer.getCredentialsSupported()
-                                               .get(credentialConfigurationId)
-                                               .getProofTypesSupported()
-                                               .getSupportedProofTypes()
-                                               .get("jwt")
-                                               .getSigningAlgorithmsSupported()
-                                               .contains("ES256"));
+                            credentialIssuer.getCredentialsSupported()
+                                    .get(credentialConfigurationId)
+                                    .getProofTypesSupported()
+                                    .getSupportedProofTypes()
+                                    .get("jwt")
+                                    .getSigningAlgorithmsSupported()
+                                    .contains("ES256"));
                     assertEquals("The sd-jwt-credential should display as Test Credential",
                                  credentialConfigurationId,
                                  credentialIssuer.getCredentialsSupported().get(credentialConfigurationId)
@@ -519,9 +533,9 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
     public static ClientScopeModel createCredentialScope(KeycloakSession session) {
         RealmModel realmModel = session.getContext().getRealm();
         ClientScopeModel credentialScope = session.clientScopes()
-                                                  .addClientScope(realmModel, jwtTypeCredentialScopeName);
+                .addClientScope(realmModel, jwtTypeCredentialScopeName);
         credentialScope.setAttribute(CredentialScopeModel.CREDENTIAL_IDENTIFIER,
-                                     jwtTypeCredentialScopeName);
+                jwtTypeCredentialScopeName);
         credentialScope.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
         return credentialScope;
     }
@@ -566,10 +580,10 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
             assertEquals("lastName claim incorrectly mapped.", "Doe", disclosureMap.get("lastName").get(2).asText());
             assertTrue("The credentials should include the roles claim.", disclosureMap.containsKey("roles"));
             assertTrue("The credentials should include the scope-name claim.",
-                       disclosureMap.containsKey("scope-name"));
+                    disclosureMap.containsKey("scope-name"));
             assertEquals("The credentials should include the scope-name claims correct value.",
-                         clientScope.getName(),
-                         disclosureMap.get("scope-name").get(2).textValue());
+                    clientScope.getName(),
+                    disclosureMap.get("scope-name").get(2).textValue());
             assertTrue("The credentials should include the email claim.", disclosureMap.containsKey("email"));
             assertEquals("email claim incorrectly mapped.", "john@email.cz", disclosureMap.get("email").get(2).asText());
 


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
This PR aims at updating the credential endpoint to understand multiple credential issuance in single call flow and also returning an invalid_nonce error when at least one of the key proofs contains an invalid c_nonce value.

Closes:
https://github.com/keycloak/keycloak/issues/39277
https://github.com/keycloak/keycloak/issues/39292