### PR TITLE
Update OID4VCI error handling to align with draft 16 specification

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/ErrorType.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/ErrorType.java
@@ -20,7 +20,7 @@ package org.keycloak.protocol.oid4vc.model;
 
 /**
  * Enum to handle potential errors in issuing credentials with the error types defined in OID4VCI
- * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html}
+ * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-16.html}
  *
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
  */
@@ -28,8 +28,8 @@ public enum ErrorType {
 
     INVALID_CREDENTIAL_REQUEST("invalid_credential_request"),
     INVALID_TOKEN("invalid_token"),
-    UNSUPPORTED_CREDENTIAL_TYPE("unsupported_credential_type"),
-    UNSUPPORTED_CREDENTIAL_FORMAT("unsupported_credential_format"),
+    UNKNOWN_CREDENTIAL_CONFIGURATION("unknown_credential_configuration"),
+    UNKNOWN_CREDENTIAL_IDENTIFIER("unknown_credential_identifier"),
     INVALID_PROOF("invalid_proof"),
     INVALID_ENCRYPTION_PARAMETERS("invalid_encryption_parameters"),
     MISSING_CREDENTIAL_CONFIG("missing_credential_config"),


### PR DESCRIPTION
This PR updates the OID4VCI implementation to align with the new error types introduced in Draft 16.

## Changes
- **ErrorType enum**: Replaced `UNSUPPORTED_CREDENTIAL_TYPE` and `UNSUPPORTED_CREDENTIAL_FORMAT` with `UNKNOWN_CREDENTIAL_CONFIGURATION`
- **New error type**: Added `UNKNOWN_CREDENTIAL_IDENTIFIER` for when credential_identifier is not recognized
- **Error handling logic**: Updated to differentiate between credential configuration and identifier errors based on request parameters
- **Tests**: Added comprehensive test coverage for all new error scenarios

Closes #95 