### PR TITLE
[OID4VCI]: Enforce batch_size ≥ 2 validation for batch_credential_issuance

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
@@ -29,6 +29,8 @@ public final class Oid4VciConstants {
 
     public static final String CREDENTIAL_SUBJECT = "credentialSubject";
 
+    public static final String BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE = "batch_credential_issuance.batch_size";
+
     private Oid4VciConstants() {
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -91,14 +91,29 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
     }
 
     private CredentialIssuer.BatchCredentialIssuance getBatchCredentialIssuance(KeycloakSession session) {
-        RealmModel realm = session.getContext().getRealm();
-        String batchSize = realm.getAttribute("batch_credential_issuance.batch_size");
+        return getBatchCredentialIssuance(session.getContext().getRealm());
+    }
+
+    /**
+     * Returns the batch credential issuance configuration for the given realm.
+     * This method is public and static to facilitate testing without requiring session state management.
+     *
+     * @param realm The realm model
+     * @return The batch credential issuance configuration or null if not configured or invalid
+     */
+    public static CredentialIssuer.BatchCredentialIssuance getBatchCredentialIssuance(RealmModel realm) {
+        String batchSize = realm.getAttribute(Oid4VciConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE);
         if (batchSize != null) {
             try {
+                int parsedBatchSize = Integer.parseInt(batchSize);
+                if (parsedBatchSize < 2) {
+                    LOGGER.warnf("%s must be 2 or greater, but was %d. Skipping batch_credential_issuance.", Oid4VciConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE, parsedBatchSize);
+                    return null;
+                }
                 return new CredentialIssuer.BatchCredentialIssuance()
-                        .setBatchSize(Integer.parseInt(batchSize));
+                        .setBatchSize(parsedBatchSize);
             } catch (Exception e) {
-                LOGGER.warnf(e, "Failed to parse batch_credential_issuance.batch_size from realm attributes.");
+                LOGGER.warnf(e, "Failed to parse %s from realm attributes.", Oid4VciConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE);
             }
         }
         return null;


### PR DESCRIPTION
## Summary
This PR implements validation for the `batch_credential_issuance.batch_size` parameter to ensure compliance with the OID4VCI specification, which requires that `batch_size` MUST be 2 or greater.

## Changes Made

### Implementation
- Added validation in `getBatchCredentialIssuance()` method to check that `batch_size` is at least 2

### Testing
- Added comprehensive test method `testBatchCredentialIssuanceValidation()` covering:
    - Valid cases: batch sizes 2, 5 (should be accepted)
    - Invalid cases: batch sizes -1, 0, 1 (should be rejected)
    - Edge case: batch size exactly 2 (minimum valid value)
  - Created reusable helper method `testBatchSizeValidation()` to reduce code duplication
  - Ensured tests don't interfere with each other by properly restoring original realm attributes

## Addresses
- Issue https://github.com/adorsys/keycloak-oid4vc/issues/77