### PR TITLE
[OID4VCI]: Implement draft -16 compliant well-known endpoint with content negotiation and internationalization

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
@@ -29,6 +29,8 @@ public final class Oid4VciConstants {
 
     public static final String CREDENTIAL_SUBJECT = "credentialSubject";
 
+    public static final String SIGNED_METADATA_JWT_TYPE = "openidvci-issuer-metadata+jwt";
+
     private Oid4VciConstants() {
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialIssuer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialIssuer.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 /**
  * Represents a credentials issuer according to the OID4VCI Credentials Issuer Metadata
- * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-credential-issuer-metadata}
+ * {@see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata}
  *
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
  */
@@ -54,9 +54,6 @@ public class CredentialIssuer {
 
     @JsonProperty("batch_credential_issuance")
     private BatchCredentialIssuance batchCredentialIssuance;
-
-    @JsonProperty("signed_metadata")
-    private String signedMetadata;
 
     @JsonProperty("credential_configurations_supported")
     private Map<String, SupportedCredentialConfiguration> credentialsSupported;
@@ -127,15 +124,6 @@ public class CredentialIssuer {
 
     public CredentialIssuer setBatchCredentialIssuance(BatchCredentialIssuance batchCredentialIssuance) {
         this.batchCredentialIssuance = batchCredentialIssuance;
-        return this;
-    }
-
-    public String getSignedMetadata() {
-        return signedMetadata;
-    }
-
-    public CredentialIssuer setSignedMetadata(String signedMetadata) {
-        this.signedMetadata = signedMetadata;
         return this;
     }
 


### PR DESCRIPTION
This PR implements content negotiation and internationalization support for the Credential Issuer Metadata well-known endpoint according to the OID4VCI specification.

## Key Changes

### 1. Content Negotiation Support
- Add support for `Accept: application/jwt` to return signed metadata as JWT
- Add support for `Accept: application/json` (default) for unsigned metadata
- Implement proper error handling: return `406 Not Acceptable` when JWT signing fails instead of falling back to JSON

### 2. JWT Metadata Signing
- Implement signed metadata according to OID4VCI spec section 11.2.3
- JOSE header: `alg: RS256`, `typ: openidvci-issuer-metadata+jwt`, `kid: present`
- JWT payload: `iss`, `sub`, `iat`, `exp`, `metadata` claim
- Use Keycloak's `JWSBuilder` and `SignatureProvider` for secure signing

### 3. Internationalization Support
- Add support for `Accept-Language` header processing
- Return `Content-Language` header in response
- Display information only returned when internationalization is enabled AND Accept-Language header is present

### 4. Draft 16 Compliance
- Remove `signed_metadata` field from `CredentialIssuer` model (no longer in spec)

## Testing
- ✅ Content negotiation tests (JSON vs JWT responses)
- ✅ Internationalization tests (Accept-Language header processing)
- ✅ JWT signing validation (header and payload verification)
- ✅ Error handling tests (406 Not Acceptable scenarios)

## Addresses
- Issue: https://github.com/adorsys/keycloak-oid4vc/issues/107