### PR TITLE
[Datev Stable] Return the new invalid_nonce error if proofs are invalid because of an invalid nonce

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -69,6 +69,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryption;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryptionMetadata;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.services.ErrorResponseException;
 import org.keycloak.protocol.oid4vc.model.ErrorResponse;
 import org.keycloak.protocol.oid4vc.model.ErrorType;
 import org.keycloak.protocol.oid4vc.model.Format;
@@ -801,6 +802,13 @@ public class OID4VCIssuerEndpoint {
                 vcIssuanceContext.getCredentialBody().addKeyBinding(jwks.get(0));
             }
         } catch (VCIssuerException e) {
+            if (e.getErrorType() == ErrorType.INVALID_NONCE) {
+                throw new ErrorResponseException(
+                        ErrorType.INVALID_NONCE.getValue(),
+                        "The proofs parameter in the Credential Request uses an invalid nonce",
+                        Response.Status.BAD_REQUEST
+                );
+            }
             throw new BadRequestException("Could not validate provided proof", e);
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/VCIssuerException.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/VCIssuerException.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.protocol.oid4vc.issuance;
 
+import org.keycloak.protocol.oid4vc.model.ErrorType;
+
 /**
  * Exception to be thrown in case credentials issuance fails.
  *
@@ -24,11 +26,24 @@ package org.keycloak.protocol.oid4vc.issuance;
  */
 public class VCIssuerException extends RuntimeException {
 
+    private final ErrorType errorType;
+
     public VCIssuerException(String message) {
         super(message);
+        this.errorType = null;
     }
 
     public VCIssuerException(String message, Throwable cause) {
         super(message, cause);
+        this.errorType = null;
+    }
+
+    public VCIssuerException(ErrorType errorType, String message, Throwable cause) {
+        super(message, cause);
+        this.errorType = errorType;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
@@ -28,6 +28,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
+import org.keycloak.protocol.oid4vc.model.ErrorType;
 import org.keycloak.protocol.oid4vc.model.JwtProof;
 import org.keycloak.protocol.oid4vc.model.Proof;
 import org.keycloak.protocol.oid4vc.model.ProofType;
@@ -266,9 +267,15 @@ public class JwtProofValidator extends AbstractProofValidator {
 
         KeycloakContext keycloakContext = keycloakSession.getContext();
         CNonceHandler cNonceHandler = keycloakSession.getProvider(CNonceHandler.class);
-        cNonceHandler.verifyCNonce(proofPayload.getNonce(),
-                List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
-                Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
-                        OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext)));
+
+        try {
+            cNonceHandler.verifyCNonce(proofPayload.getNonce(),
+                    List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
+                    Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
+                            OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext)));
+        } catch (VerificationException e) {
+            throw new VCIssuerException(ErrorType.INVALID_NONCE,
+                    "The proofs parameter in the Credential Request uses an invalid nonce", e);
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/ErrorType.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/ErrorType.java
@@ -31,6 +31,7 @@ public enum ErrorType {
     UNKNOWN_CREDENTIAL_CONFIGURATION("unknown_credential_configuration"),
     UNKNOWN_CREDENTIAL_IDENTIFIER("unknown_credential_identifier"),
     INVALID_PROOF("invalid_proof"),
+    INVALID_NONCE("invalid_nonce"),
     INVALID_ENCRYPTION_PARAMETERS("invalid_encryption_parameters"),
     MISSING_CREDENTIAL_CONFIG("missing_credential_config"),
     MISSING_CREDENTIAL_IDENTIFIER_AND_CONFIGURATION_ID("missing_credential_identifier_and_configuration_id");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
@@ -21,7 +21,6 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -72,6 +71,7 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.ComponentExportRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.JsonSerialization;
@@ -181,12 +181,8 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                         testRequestTestCredential(session, clientScope, token, proof);
                     })));
             Assert.fail("Should have thrown an exception");
-        } catch (BadRequestException ex) {
-            Assert.assertEquals("""
-                                        c_nonce: expected 'aud' to be equal to \
-                                        '[https://localhost:8543/auth/realms/test/protocol/oid4vc/credential]' but \
-                                        actual value was '[]'""",
-                    ExceptionUtils.getRootCause(ex).getMessage());
+        } catch (ErrorResponseException ex) {
+            Assert.assertEquals("invalid_nonce", ex.getMessage());
         }
     }
 
@@ -211,12 +207,8 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                         testRequestTestCredential(session, clientScope, token, proof);
                     })));
             Assert.fail("Should have thrown an exception");
-        } catch (BadRequestException ex) {
-            Assert.assertEquals("""
-                                        c_nonce: expected 'source_endpoint' to be equal to \
-                                        'https://localhost:8543/auth/realms/test/protocol/oid4vc/nonce' but \
-                                        actual value was 'null'""",
-                    ExceptionUtils.getRootCause(ex).getMessage());
+        } catch (ErrorResponseException ex) {
+            Assert.assertEquals("invalid_nonce", ex.getMessage());
         }
     }
 
@@ -249,10 +241,8 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                         }
                     })));
             Assert.fail("Should have thrown an exception");
-        } catch (BadRequestException ex) {
-            String message = ExceptionUtils.getRootCause(ex).getMessage();
-            Assert.assertTrue(String.format("Message '%s' should match regular expression", message),
-                    message.matches("c_nonce not valid: \\d+\\(exp\\) < \\d+\\(now\\)"));
+        } catch (ErrorResponseException ex) {
+            Assert.assertEquals("invalid_nonce", ex.getMessage());
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/adorsys/keycloak-oid4vc/issues/39