### PR TITLE
[OID4VCI] Adjust Credential Issuer Metadata endpoint, return issuer metadata at /.well-known/openid-credential-issuer/realms/{realm}

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -29,10 +29,10 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProviderFactory;
 import org.keycloak.protocol.oauth2.OAuth2WellKnownProviderFactory;
 import org.keycloak.services.cors.Cors;
-
-import java.util.List;
+import static org.keycloak.utils.MediaType.APPLICATION_JWT;
 
 @Provider
 @Path("/.well-known")
@@ -54,7 +54,7 @@ public class ServerMetadataResource {
 
     @GET
     @Path("{provider}/realms/{realm}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, APPLICATION_JWT})
     public Response getOAuth2AuthorizationServerWellKnown(final @PathParam("provider") String providerName,
                                                           final @PathParam("realm") String name) {
         if (!isValidProvider(providerName)) throw new NotFoundException();
@@ -68,6 +68,7 @@ public class ServerMetadataResource {
     private boolean isValidProvider(String providerName) {
         // you can add codes here considering the current status of the implementation (preview, experimental).
         if (OAuth2WellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
+        if (OID4VCIssuerWellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
         return false;
     }
 }


### PR DESCRIPTION
This PR adds support for the spec-defined metadata endpoint while keeping the legacy route operational.

New endpoint:
- Path: /.well-known/openid-credential-issuer/realms/{realm}
- Returns metadata

Legacy endpoint:
- Path: /realms/{realm}/.well-known/openid-credential-issuer
- Still supported for compatibility
- Returns Warning/Deprecation/Link headers
- Logs a one-time WARN per realm+alias on first access

Note:
- Integration tests continue to use the legacy path due to Undertow test-container context-root (/auth) behavior. Runtime is unaffected.

Backwards compatibility:
- Maintained. Legacy clients continue to function, but are clearly warned to migrate.

Closes #83 