### PR TITLE
[Stable] Update the issuer metadata for signed metadata

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
@@ -38,6 +38,8 @@ public final class Oid4VciConstants {
     public static final String SOURCE_ENDPOINT = "source_endpoint";
     public static final String BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE = "batch_credential_issuance.batch_size";
 
+    public static final String SIGNED_METADATA_JWT_TYPE = "openidvci-issuer-metadata+jwt";
+
     private Oid4VciConstants() {
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -18,12 +18,17 @@
 package org.keycloak.protocol.oid4vc.issuance;
 
 import jakarta.ws.rs.core.UriInfo;
+import org.apache.http.HttpHeaders;
+import org.keycloak.common.util.Time;
 import org.keycloak.constants.Oid4VciConstants;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.jose.jwe.JWEConstants;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.models.KeyManager;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
@@ -35,15 +40,15 @@ import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 
 import org.keycloak.protocol.oid4vc.model.CredentialRequestEncryptionMetadata;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryptionMetadata;
-import org.keycloak.protocol.oid4vc.model.CredentialRequestEncryptionMetadata;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.protocol.oidc.utils.JWKSServerUtils;
 import org.keycloak.services.Urls;
 import org.keycloak.urls.UrlType;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.MediaType;
 import org.keycloak.wellknown.WellKnownProvider;
 import org.jboss.logging.Logger;
-import org.keycloak.jose.jwk.JWK;
-import org.keycloak.jose.jwk.JSONWebKeySet;
 
 import java.util.Arrays;
 import java.util.List;
@@ -51,7 +56,17 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.keycloak.constants.Oid4VciConstants.SIGNED_METADATA_JWT_TYPE;
+import static org.keycloak.crypto.Algorithm.ES256;
+import static org.keycloak.crypto.Algorithm.ES384;
+import static org.keycloak.crypto.Algorithm.ES512;
+import static org.keycloak.crypto.Algorithm.PS256;
+import static org.keycloak.crypto.Algorithm.PS384;
+import static org.keycloak.crypto.Algorithm.PS512;
+import static org.keycloak.crypto.Algorithm.RS384;
+import static org.keycloak.crypto.Algorithm.RS512;
 import static org.keycloak.crypto.KeyType.RSA;
+import static org.keycloak.jose.jwk.RSAPublicJWK.RS256;
 
 /**
  * {@link WellKnownProvider} implementation to provide the .well-known/openid-credential-issuer endpoint, offering
@@ -62,16 +77,27 @@ import static org.keycloak.crypto.KeyType.RSA;
  */
 public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
 
-    public static final String VC_KEY = "vc";
-
     private static final Logger LOGGER = Logger.getLogger(OID4VCIssuerWellKnownProvider.class);
 
-    protected final KeycloakSession keycloakSession;
+    // Realm attributes for signed metadata configuratio
+    public static final String SIGNED_METADATA_ENABLED_ATTR = "oid4vci.signed_metadata.enabled";
+    public static final String SIGNED_METADATA_LIFESPAN_ATTR = "oid4vci.signed_metadata.lifespan";
+    public static final String SIGNED_METADATA_ALG_ATTR = "oid4vci.signed_metadata.alg";
 
+    public static final String VC_KEY = "vc";
     public static final String ATTR_ENCRYPTION_REQUIRED = "oid4vci.encryption.required";
 
     public static final String DEFLATE_COMPRESSION = "DEF";
     public static final String ATTR_REQUEST_ZIP_ALGS = "oid4vci.request.zip.algorithms";
+    
+    // Static list of supported asymmetric algorithms
+    private static final List<String> ASYMMETRIC_ALGORITHMS = Arrays.asList(
+            RS256, RS384, RS512,
+            ES256, ES384, ES512,
+            PS256, PS384, PS512
+    );
+
+    protected final KeycloakSession keycloakSession;
 
     public OID4VCIssuerWellKnownProvider(KeycloakSession keycloakSession) {
         this.keycloakSession = keycloakSession;
@@ -84,6 +110,11 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
 
     @Override
     public Object getConfig() {
+        CredentialIssuer issuer = getIssuerMetadata();
+        return getMetadataResponse(issuer, keycloakSession);
+    }
+
+    public CredentialIssuer getIssuerMetadata() {
         KeycloakContext context = keycloakSession.getContext();
         return new CredentialIssuer()
                 .setCredentialIssuer(getIssuer(context))
@@ -95,7 +126,29 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
                 .setCredentialResponseEncryption(getCredentialResponseEncryption(keycloakSession))
                 .setCredentialRequestEncryption(getCredentialRequestEncryption(keycloakSession))
                 .setBatchCredentialIssuance(getBatchCredentialIssuance(keycloakSession))
-                .setSignedMetadata(getSignedMetadata(keycloakSession));
+                .setCredentialRequestEncryption(getCredentialRequestEncryption(keycloakSession));
+    }
+
+    public Object getMetadataResponse(CredentialIssuer issuer, KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        String acceptHeader = session.getContext().getRequestHeaders().getHeaderString(HttpHeaders.ACCEPT);
+        boolean preferJwt = acceptHeader != null && acceptHeader.contains(MediaType.APPLICATION_JWT);
+        boolean signedMetadataEnabled = Boolean.parseBoolean(realm.getAttribute(SIGNED_METADATA_ENABLED_ATTR));
+
+        if (preferJwt && signedMetadataEnabled) {
+            String signedJwt = null;
+            try {
+                signedJwt = generateSignedMetadata(issuer, session);
+            } catch (Exception e) {
+                LOGGER.warnf(e, "Failed to generate signed metadata for realm: %s", realm.getName());
+            }
+            if (signedJwt != null) {
+                return signedJwt;
+            } else {
+                LOGGER.debugf("Falling back to JSON response due to signed metadata failure for realm: %s", realm.getName());
+            }
+        }
+        return issuer;
     }
 
     private static String getDeferredCredentialEndpoint(KeycloakContext context) {
@@ -104,11 +157,6 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
 
     private CredentialIssuer.BatchCredentialIssuance getBatchCredentialIssuance(KeycloakSession session) {
         return getBatchCredentialIssuance(session.getContext().getRealm());
-    }
-
-    private String getSignedMetadata(KeycloakSession session) {
-        RealmModel realm = session.getContext().getRealm();
-        return realm.getAttribute("signed_metadata");
     }
 
     /**
@@ -137,7 +185,126 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
     }
 
     /**
-     * Returns the credential response encryption высоко for the issuer.
+     * Generates signed metadata as a JWS using JsonWebToken infrastructure.
+     *
+     * @param metadata The CredentialIssuer metadata object to sign.
+     * @param session  The Keycloak session.
+     * @return The compact JWS string.
+     * @throws IllegalStateException if generation fails due to configuration or signing issues.
+     */
+    public String generateSignedMetadata(CredentialIssuer metadata, KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        KeyManager keyManager = session.keys();
+
+        // Select asymmetric signing algorithm
+        String alg;
+        try {
+            alg = getSigningAlgorithm(realm, session);
+        } catch (IllegalStateException e) {
+            LOGGER.warnf("Failed to get signing algorithm: %s. Falling back to unsigned metadata.", e.getMessage());
+            return null; // Return null to indicate fallback to JSON
+        }
+
+        // Retrieve active key
+        KeyWrapper keyWrapper = keyManager.getActiveKey(realm, KeyUse.SIG, alg);
+        if (keyWrapper == null) {
+            throw new IllegalStateException(
+                    String.format("No active key found for realm '%s' with algorithm '%s'", realm.getName(), alg));
+        }
+
+        // Create JsonWebToken with metadata as claims
+        JsonWebToken jwt = createMetadataJwt(metadata, realm);
+
+        // Validate lifespan configuration
+        String lifespanStr = realm.getAttribute(SIGNED_METADATA_LIFESPAN_ATTR);
+        if (lifespanStr != null) {
+            try {
+                long lifespan = Long.parseLong(lifespanStr);
+                jwt.exp(Time.currentTime() + lifespan);
+            } catch (NumberFormatException e) {
+                LOGGER.warnf("Invalid lifespan duration for signed metadata: %s. Falling back to unsigned metadata.", lifespanStr);
+                return null; // Return null to indicate fallback to JSON
+            }
+        }
+
+        // Build JWS with proper headers
+        JWSBuilder jwsBuilder = new JWSBuilder()
+                .type(SIGNED_METADATA_JWT_TYPE)
+                .kid(keyWrapper.getKid());
+
+        // Add x5c certificate chain if available
+        addCertificateHeaders(jwsBuilder, keyWrapper, realm);
+
+        // Sign the JWS
+        SignatureProvider signerProvider = session.getProvider(SignatureProvider.class, alg);
+        if (signerProvider == null) {
+            throw new IllegalStateException("No signature provider for algorithm: " + alg);
+        }
+
+        SignatureSignerContext signer = signerProvider.signer(keyWrapper);
+        if (signer == null) {
+            throw new IllegalStateException("No signer context for algorithm: " + alg);
+        }
+
+        try {
+            return jwsBuilder.jsonContent(jwt).sign(signer);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to sign metadata", e);
+        }
+    }
+
+
+    private String getSigningAlgorithm(RealmModel realm, KeycloakSession session) {
+        List<String> supportedAlgorithms = getSupportedSignatureAlgorithms(session)
+                .stream()
+                .filter(ASYMMETRIC_ALGORITHMS::contains)
+                .collect(Collectors.toList());
+
+        if (supportedAlgorithms.isEmpty()) {
+            throw new IllegalStateException("No asymmetric signing algorithms available for realm: " + realm.getName());
+        }
+
+        String configuredAlg = realm.getAttribute(SIGNED_METADATA_ALG_ATTR);
+        if (configuredAlg != null) {
+            if (!supportedAlgorithms.contains(configuredAlg)) {
+                throw new IllegalStateException("Configured signing algorithm '" + configuredAlg + "' is not supported for realm: " + realm.getName());
+            }
+            // Use the configured algorithm if present and supported
+            return configuredAlg;
+        }
+
+        // Prefer RS256 if available, otherwise use the first supported asymmetric algorithm
+        return supportedAlgorithms.contains(RS256) ? RS256 : supportedAlgorithms.get(0);
+    }
+
+    private JsonWebToken createMetadataJwt(CredentialIssuer metadata, RealmModel realm) {
+        JsonWebToken jwt = new JsonWebToken();
+
+        // Set standard JWT claims
+        jwt.subject(metadata.getCredentialIssuer());
+        jwt.issuer(metadata.getCredentialIssuer());
+        jwt.issuedNow();
+
+        // Convert metadata to map and add as other claims
+        Map<String, Object> metadataClaims = JsonSerialization.mapper.convertValue(metadata, Map.class);
+        metadataClaims.forEach(jwt::setOtherClaims);
+
+        return jwt;
+    }
+
+    private void addCertificateHeaders(JWSBuilder jwsBuilder, KeyWrapper keyWrapper, RealmModel realm) {
+        if (keyWrapper.getCertificateChain() != null && !keyWrapper.getCertificateChain().isEmpty()) {
+            jwsBuilder.x5c(keyWrapper.getCertificateChain());
+        } else if (keyWrapper.getCertificate() != null) {
+            jwsBuilder.x5c(List.of(keyWrapper.getCertificate()));
+        } else {
+            LOGGER.debugf("No certificate or certificate chain available for x5c header in realm: %s", realm.getName());
+        }
+    }
+
+
+    /**
+     * Returns the credential response encryption for the issuer.
      * Now determines supported algorithms from available realm keys.
      *
      * @param session The Keycloak session

--- a/services/src/main/java/org/keycloak/services/resources/RealmsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/RealmsResource.java
@@ -50,13 +50,14 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.Provider;
 
 import java.net.URI;
 import java.util.Comparator;
+
+import static org.keycloak.utils.MediaType.APPLICATION_JWT;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -222,7 +223,7 @@ public class RealmsResource {
 
     @GET
     @Path("{realm}/.well-known/{alias}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, APPLICATION_JWT})
     public Response getWellKnown(final @PathParam("realm") String name,
                                  final @PathParam("alias") String alias) {
         resolveRealmAndUpdateSession(name);
@@ -239,8 +240,13 @@ public class RealmsResource {
         WellKnownProvider wellKnown = session.getProvider(WellKnownProvider.class, wellKnownProviderFactoryFound.getId());
 
         if (wellKnown != null) {
-            ResponseBuilder responseBuilder = Response.ok(wellKnown.getConfig()).cacheControl(CacheControlUtil.noCache());
-            return Cors.builder().allowAllOrigins().auth().add(responseBuilder);
+            Object config = wellKnown.getConfig();
+            Response.ResponseBuilder responseBuilder;
+
+            // Check if the provider returned a JWT string or JSON object
+            responseBuilder = Response.ok(config).type(config instanceof String ? APPLICATION_JWT : MediaType.APPLICATION_JSON);
+
+            return Cors.builder().allowAllOrigins().auth().add(responseBuilder.cacheControl(CacheControlUtil.noCache()));
         }
 
         throw new NotFoundException();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -709,9 +709,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .server(TEST_REALM_NAME)
                 .run((session -> {
                     OID4VCIssuerWellKnownProvider oid4VCIssuerWellKnownProvider = new OID4VCIssuerWellKnownProvider(session);
-                    Object issuerConfig = oid4VCIssuerWellKnownProvider.getConfig();
-                    assertTrue("Valid credential-issuer metadata should be returned.", issuerConfig instanceof CredentialIssuer);
-                    CredentialIssuer credentialIssuer = (CredentialIssuer) issuerConfig;
+                    CredentialIssuer credentialIssuer = oid4VCIssuerWellKnownProvider.getIssuerMetadata();
                     assertEquals("The correct issuer should be included.", expectedIssuer, credentialIssuer.getCredentialIssuer());
                     assertEquals("The correct credentials endpoint should be included.", expectedCredentialsEndpoint, credentialIssuer.getCredentialEndpoint());
                     assertEquals("The correct nonce endpoint should be included.",

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
@@ -386,9 +386,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                 .server(TEST_REALM_NAME)
                 .run((session -> {
                     OID4VCIssuerWellKnownProvider oid4VCIssuerWellKnownProvider = new OID4VCIssuerWellKnownProvider(session);
-                    Object issuerConfig = oid4VCIssuerWellKnownProvider.getConfig();
-                    assertTrue("Valid credential-issuer metadata should be returned.", issuerConfig instanceof CredentialIssuer);
-                    CredentialIssuer credentialIssuer = (CredentialIssuer) issuerConfig;
+                    CredentialIssuer credentialIssuer = oid4VCIssuerWellKnownProvider.getIssuerMetadata();
                     assertEquals("The correct issuer should be included.", expectedIssuer, credentialIssuer.getCredentialIssuer());
                     assertEquals("The correct credentials endpoint should be included.", expectedCredentialsEndpoint, credentialIssuer.getCredentialEndpoint());
                     assertEquals("The correct nonce endpoint should be included.",


### PR DESCRIPTION
## Summary

Update metadata retrieval to support signed metadata `(application/jwt)` alongside unsigned `(application/json)`, including sending an Accept header and validating JWS headers `(alg, typ: openidvci-issuer-metadata+jwt)` and JWT claims `(iss, sub, iat, exp)`.

See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-16.html#name-signed-metadata

## Related To
Issue https://github.com/adorsys/keycloak-oid4vc/issues/81