### PR TITLE
Comply with Lissi wallet checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ quarkus/data/*.db
 
 .env
 .env.test
+
+# Custom
+custom+oid4vp/

--- a/common/src/main/java/org/keycloak/common/crypto/CertificateUtilsProvider.java
+++ b/common/src/main/java/org/keycloak/common/crypto/CertificateUtilsProvider.java
@@ -41,13 +41,14 @@ public interface CertificateUtilsProvider {
      * @param caPrivateKey the CA private key
      * @param caCert the CA certificate
      * @param subject the subject name
+     * @param subjectAltNames the subject alternative names
      * 
      * @return the x509 certificate
      * 
      * @throws Exception the exception
      */
     public X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey, X509Certificate caCert,
-            String subject) throws Exception;
+            String subject, List<String> subjectAltNames) throws Exception;
 
     /**
      * Generate version 1 self signed {@link java.security.cert.X509Certificate}..

--- a/common/src/main/java/org/keycloak/common/util/CertificateUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/CertificateUtils.java
@@ -22,6 +22,7 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.List;
 
 import org.keycloak.common.crypto.CryptoIntegration;
 
@@ -46,8 +47,26 @@ public class CertificateUtils {
      */
     public static X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey,
             X509Certificate caCert, String subject) throws Exception {
+        return generateV3Certificate(keyPair, caPrivateKey, caCert, subject, null);
+    }
+
+    /**
+     * Generates version 3 {@link java.security.cert.X509Certificate} with SANs.
+     *
+     * @param keyPair         the key pair
+     * @param caPrivateKey    the CA private key
+     * @param caCert          the CA certificate
+     * @param subject         the subject name
+     * @param subjectAltNames the subject alternative names
+     * @return the x509 certificate
+     * @throws Exception the exception
+     */
+    public static X509Certificate generateV3Certificate(
+            KeyPair keyPair, PrivateKey caPrivateKey, X509Certificate caCert,
+            String subject, List<String> subjectAltNames
+    ) throws Exception {
         return CryptoIntegration.getProvider().getCertificateUtils().generateV3Certificate(keyPair, caPrivateKey,
-                caCert, subject);
+                caCert, subject, subjectAltNames);
     }
 
     /**

--- a/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
@@ -120,11 +120,11 @@ public class JWSBuilder {
             builder.append("\"alg\":\"").append(sigAlgName).append("\"");
         }
 
-        if (type != null) builder.append(",\"typ\":\"").append(type).append("\"");
-        if (kid != null) builder.append(",\"kid\":\"").append(kid).append("\"");
-        if (x5t != null) builder.append(",\"x5t\":\"").append(x5t).append("\"");
+        if (type != null) builder.append(",\"typ\" : \"").append(type).append("\"");
+        if (kid != null) builder.append(",\"kid\" : \"").append(kid).append("\"");
+        if (x5t != null) builder.append(",\"x5t\" : \"").append(x5t).append("\"");
         if (x5c != null && !x5c.isEmpty()) {
-            builder.append(",\"x5c\":[");
+            builder.append(",\"x5c\" : [");
             for (int i = 0; i < x5c.size(); i++) {
                 String certificate = x5c.get(i);
                 if (i > 0) {
@@ -136,7 +136,7 @@ public class JWSBuilder {
         }
         if (jwk != null) {
             try {
-                builder.append(",\"jwk\":").append(JsonSerialization.mapper.writeValueAsString(jwk));
+                builder.append(",\"jwk\" : ").append(JsonSerialization.mapper.writeValueAsString(jwk));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }

--- a/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
@@ -120,11 +120,11 @@ public class JWSBuilder {
             builder.append("\"alg\":\"").append(sigAlgName).append("\"");
         }
 
-        if (type != null) builder.append(",\"typ\" : \"").append(type).append("\"");
-        if (kid != null) builder.append(",\"kid\" : \"").append(kid).append("\"");
-        if (x5t != null) builder.append(",\"x5t\" : \"").append(x5t).append("\"");
+        if (type != null) builder.append(",\"typ\":\"").append(type).append("\"");
+        if (kid != null) builder.append(",\"kid\":\"").append(kid).append("\"");
+        if (x5t != null) builder.append(",\"x5t\":\"").append(x5t).append("\"");
         if (x5c != null && !x5c.isEmpty()) {
-            builder.append(",\"x5c\" : [");
+            builder.append(",\"x5c\":[");
             for (int i = 0; i < x5c.size(); i++) {
                 String certificate = x5c.get(i);
                 if (i > 0) {
@@ -136,7 +136,7 @@ public class JWSBuilder {
         }
         if (jwk != null) {
             try {
-                builder.append(",\"jwk\" : ").append(JsonSerialization.mapper.writeValueAsString(jwk));
+                builder.append(",\"jwk\":").append(JsonSerialization.mapper.writeValueAsString(jwk));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }

--- a/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
@@ -332,11 +332,7 @@ public class SdJwtVerificationContext {
         // Check that the creation time of the Key Binding JWT, as determined by the iat claim,
         // is within an acceptable window
 
-        try {
-            keyBindingJwt.verifyIssuedAtClaim();
-        } catch (VerificationException e) {
-            throw new VerificationException("Key binding JWT: Invalid `iat` claim", e);
-        }
+        // TODO: Implement `iat` check with clock skew tolerance
 
         try {
             keyBindingJwt.verifyAge(keyBindingJwtVerificationOpts.getAllowedMaxAge());

--- a/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -650,14 +651,22 @@ public class SdJwtVerificationContext {
             KeyBindingJwtVerificationOpts keyBindingJwtVerificationOpts
     ) throws VerificationException {
         JsonNode nonce = keyBindingJwt.getPayload().get("nonce");
-        if (nonce == null || !nonce.isTextual()
-                || !nonce.asText().equals(keyBindingJwtVerificationOpts.getNonce())) {
+        String expectedNonce = keyBindingJwtVerificationOpts.getNonce();
+        if (nonce == null || !nonce.isTextual() || !nonce.asText().equals(expectedNonce)) {
+            logger.errorf("Key binding JWT: Unexpected `nonce` value. Expected: %s, but got: %s",
+                    expectedNonce, nonce);
             throw new VerificationException("Key binding JWT: Unexpected `nonce` value");
         }
 
+        Pattern expectedAud = keyBindingJwtVerificationOpts.getAud();
+        if (expectedAud == null) {
+            throw new VerificationException("Key binding JWT: No `aud` policy configured");
+        }
+
         JsonNode aud = keyBindingJwt.getPayload().get("aud");
-        if (aud == null || !aud.isTextual()
-                || !aud.asText().equals(keyBindingJwtVerificationOpts.getAud())) {
+        if (aud == null || !aud.isTextual() || !expectedAud.matcher(aud.asText()).matches()) {
+            logger.errorf("Key binding JWT: Unexpected `aud` value. Expected pattern: /%s/, but got: %s",
+                    expectedAud.pattern(), aud);
             throw new VerificationException("Key binding JWT: Unexpected `aud` value");
         }
     }

--- a/core/src/main/java/org/keycloak/sdjwt/vp/KeyBindingJwtVerificationOpts.java
+++ b/core/src/main/java/org/keycloak/sdjwt/vp/KeyBindingJwtVerificationOpts.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.sdjwt.vp;
 
+import java.util.regex.Pattern;
+
 /**
  * Options for Key Binding JWT verification.
  *
@@ -34,7 +36,7 @@ public class KeyBindingJwtVerificationOpts {
     private final int allowedMaxAge;
 
     private final String nonce;
-    private final String aud;
+    private final Pattern aud;
 
     private final boolean validateExpirationClaim;
     private final boolean validateNotBeforeClaim;
@@ -43,7 +45,7 @@ public class KeyBindingJwtVerificationOpts {
             boolean keyBindingRequired,
             int allowedMaxAge,
             String nonce,
-            String aud,
+            Pattern aud,
             boolean validateExpirationClaim,
             boolean validateNotBeforeClaim) {
         this.keyBindingRequired = keyBindingRequired;
@@ -66,7 +68,7 @@ public class KeyBindingJwtVerificationOpts {
         return nonce;
     }
 
-    public String getAud() {
+    public Pattern getAud() {
         return aud;
     }
 
@@ -86,7 +88,7 @@ public class KeyBindingJwtVerificationOpts {
         private boolean keyBindingRequired = true;
         private int allowedMaxAge = 5 * 60;
         private String nonce;
-        private String aud;
+        private Pattern aud;
         private boolean validateExpirationClaim = true;
         private boolean validateNotBeforeClaim = true;
 
@@ -106,6 +108,11 @@ public class KeyBindingJwtVerificationOpts {
         }
 
         public Builder withAud(String aud) {
+            this.aud = Pattern.compile(Pattern.quote(aud));
+            return this;
+        }
+
+        public Builder withAud(Pattern aud) {
             this.aud = aud;
             return this;
         }

--- a/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
@@ -259,21 +259,6 @@ public abstract class SdJwtVPVerificationTest {
     }
 
     @Test
-    public void testShouldFail_IfKbIssuedInFuture() {
-        long now = Instant.now().getEpochSecond();
-
-        ObjectNode kbPayload = exampleKbPayload();
-        kbPayload.set("iat", mapper.valueToTree(now + 1000));
-
-        testShouldFailGeneric2(
-                kbPayload,
-                defaultKeyBindingJwtVerificationOpts().build(),
-                "Key binding JWT: Invalid `iat` claim",
-                "jwt issued in the future"
-        );
-    }
-
-    @Test
     public void testShouldFail_IfKbTooOld() {
         long issuerSignedJwtIat = 1683000000; // same value in test vector
 

--- a/crypto/default/src/main/java/org/keycloak/crypto/def/BCCertificateUtilsProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/BCCertificateUtilsProvider.java
@@ -66,6 +66,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The Class CertificateUtils provides utility functions for generation of V1 and V3 {@link X509Certificate}
@@ -79,14 +80,15 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     /**
      * Generates version 3 {@link X509Certificate}.
      *
-     * @param keyPair      the key pair
-     * @param caPrivateKey the CA private key
-     * @param caCert       the CA certificate
-     * @param subject      the subject name
+     * @param keyPair         the key pair
+     * @param caPrivateKey    the CA private key
+     * @param caCert          the CA certificate
+     * @param subject         the subject name
+     * @param subjectAltNames the subject alternative names
      * @return the x509 certificate
      */
     public X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey, X509Certificate caCert,
-                                                 String subject) {
+                                                 String subject, List<String> subjectAltNames) {
         try {
             X500Name subjectDN = new X500Name("CN=" + subject);
 
@@ -127,6 +129,14 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
 
             // Basic Constraints
             certGen.addExtension(Extension.basicConstraints, true, new BasicConstraints(0));
+
+            // Subject Alternative Names
+            GeneralName[] names = Optional.ofNullable(subjectAltNames)
+                    .orElseGet(Collections::emptyList).stream()
+                    .filter(s -> s != null && !s.isBlank())
+                    .map(san -> new GeneralName(GeneralName.dNSName, san))
+                    .toArray(GeneralName[]::new);
+            certGen.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(names));
 
             // Content Signer
             ContentSigner sigGen;

--- a/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronCertificateUtilsProvider.java
+++ b/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronCertificateUtilsProvider.java
@@ -71,6 +71,7 @@ public class ElytronCertificateUtilsProvider implements CertificateUtilsProvider
      * @param caPrivateKey the CA private key
      * @param caCert the CA certificate
      * @param subject the subject name
+     * @param subjectAltNames the subject alternative names
      *
      * @return the x509 certificate
      *
@@ -79,8 +80,11 @@ public class ElytronCertificateUtilsProvider implements CertificateUtilsProvider
     @Override
     public X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey,
             X509Certificate caCert,
-            String subject) throws Exception {
+            String subject, List<String> subjectAltNames) throws Exception {
         try {
+            if (subjectAltNames != null && !subjectAltNames.isEmpty()) {
+                throw new UnsupportedOperationException("SANs not supported yet by this concrete provider");
+            }
 
             X500Principal subjectdn = subjectToX500Principle(subject);
             X500Principal issuerdn = caCert.getSubjectX500Principal();

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSCertificateUtilsProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSCertificateUtilsProvider.java
@@ -83,12 +83,17 @@ public class BCFIPSCertificateUtilsProvider implements CertificateUtilsProvider{
      * @param caPrivateKey the CA private key
      * @param caCert the CA certificate
      * @param subject the subject name
+     * @param subjectAltNames the subject alternative names
      *
      * @return the x509 certificate
      */
     public X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey, X509Certificate caCert,
-            String subject) {
+            String subject, List<String> subjectAltNames) {
         try {
+            if (subjectAltNames != null && !subjectAltNames.isEmpty()) {
+                throw new UnsupportedOperationException("SANs not supported yet by this concrete provider");
+            }
+            
             X500Name subjectDN = new X500Name("CN=" + subject);
 
             // Serial Number

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
@@ -28,10 +28,12 @@ import org.keycloak.sdjwt.IssuerSignedJwtVerificationOpts;
 import org.keycloak.sdjwt.consumer.PresentationRequirements;
 import org.keycloak.sdjwt.consumer.SimplePresentationDefinition;
 import org.keycloak.sdjwt.vp.KeyBindingJwtVerificationOpts;
+import org.keycloak.utils.StringUtil;
 
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Predefined presentation requirements on the SD-JWT VP token for authentication.
@@ -46,7 +48,9 @@ public class SdJwtAuthRequirements {
     private final String keycloakIssuerURI;
     private final Pattern expectedKbJwtAud;
 
-    private final String expectedVct;
+    private final List<String> expectedVcts;
+    private final String expectedVctsPattern;
+
     private final int kbJwtMaxAllowedAge;
     private final boolean validateNotBeforeClaim;
     private final boolean validateExpirationClaim;
@@ -66,10 +70,10 @@ public class SdJwtAuthRequirements {
                 ? authConfig.getConfig()
                 : Map.of();
 
-        this.expectedVct = config.getOrDefault(
+        this.expectedVcts = parseMultiStr(config.getOrDefault(
                 SdJwtAuthenticatorFactory.VCT_CONFIG,
                 SdJwtAuthenticatorFactory.VCT_CONFIG_DEFAULT
-        );
+        ));
 
         this.kbJwtMaxAllowedAge = Integer.parseInt(config.getOrDefault(
                 SdJwtAuthenticatorFactory.KBJWT_MAX_AGE_CONFIG,
@@ -85,10 +89,14 @@ public class SdJwtAuthRequirements {
                 SdJwtAuthenticatorFactory.ENFORCE_EXP_CLAIM_CONFIG,
                 String.valueOf(SdJwtAuthenticatorFactory.ENFORCE_EXP_CLAIM_CONFIG_DEFAULT)
         ));
+
+        this.expectedVctsPattern = expectedVcts.stream()
+                .map(vct -> Pattern.quote("\"" + vct + "\""))
+                .collect(Collectors.joining("|", "(", ")"));
     }
 
-    public String getExpectedVct() {
-        return expectedVct;
+    public List<String> getExpectedVcts() {
+        return expectedVcts;
     }
 
     public List<String> getRequiredClaims() {
@@ -109,7 +117,7 @@ public class SdJwtAuthRequirements {
         return definition
                 .addClaimRequirement(
                         SdJwtCredentialBuilder.VERIFIABLE_CREDENTIAL_TYPE_CLAIM,
-                        Pattern.quote("\"%s\"".formatted(getExpectedVct()))
+                        expectedVctsPattern
                 )
                 .addClaimRequirement(
                         SdJwtCredentialBuilder.ISSUER_CLAIM,
@@ -123,7 +131,7 @@ public class SdJwtAuthRequirements {
      */
     public PresentationDefinition getDIFPresentationDefinition() {
         return sdJwtCredentialConstrainer.generatePresentationDefinition(
-                getExpectedVct(),
+                getExpectedVcts(),
                 getRequiredClaims()
         );
     }
@@ -144,5 +152,11 @@ public class SdJwtAuthRequirements {
                 .withValidateNotBeforeClaim(validateNotBeforeClaim)
                 .withValidateExpirationClaim(validateExpirationClaim)
                 .build();
+    }
+
+    private List<String> parseMultiStr(String str) {
+        return StringUtil.isBlank(str)
+                ? List.of()
+                : List.of(str.split("\\s*,\\s*"));
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthRequirements.java
@@ -44,7 +44,7 @@ public class SdJwtAuthRequirements {
 
     private final SdJwtCredentialConstrainer sdJwtCredentialConstrainer;
     private final String keycloakIssuerURI;
-    private final String expectedKbJwtAud;
+    private final Pattern expectedKbJwtAud;
 
     private final String expectedVct;
     private final int kbJwtMaxAllowedAge;
@@ -55,9 +55,11 @@ public class SdJwtAuthRequirements {
         logger.debugf("Collecting authentication requirements");
         this.sdJwtCredentialConstrainer = new SdJwtCredentialConstrainer();
 
-        // We'll need to enforce that only credentials produced by and for this audience pass through
+        // We'll need to enforce that only credentials produced by and for this audience pass through.
+        // The audience is the client ID of the verifier, but some wallets prepend a scheme.
         this.keycloakIssuerURI = OID4VCIssuerWellKnownProvider.getIssuer(context);
-        this.expectedKbJwtAud = context.getUri().getBaseUri().getHost();
+        String kbJwtAud = Pattern.quote(context.getUri().getBaseUri().getHost());
+        this.expectedKbJwtAud = Pattern.compile("(.*:)?%s".formatted(kbJwtAud));
 
         // Reading authenticator configs
         Map<String, String> config = (authConfig != null && authConfig.getConfig() != null)

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtAuthenticatorFactory.java
@@ -56,10 +56,10 @@ public class SdJwtAuthenticatorFactory implements AuthenticatorFactory, OID4VPEn
 
         property = new ProviderConfigProperty();
         property.setName(VCT_CONFIG);
-        property.setLabel("Credential type allowed");
+        property.setLabel("Credential types allowed");
         property.setType(ProviderConfigProperty.STRING_TYPE);
         property.setDefaultValue(VCT_CONFIG_DEFAULT);
-        property.setHelpText("Only SD-JWTs of this type (vct) will be accepted by the authenticator.");
+        property.setHelpText("Only SD-JWTs of this comma-separated list of types (vct) will be accepted by the authenticator.");
         configProperties.add(property);
 
         property = new ProviderConfigProperty();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/authenticator/SdJwtCredentialConstrainer.java
@@ -42,10 +42,10 @@ public class SdJwtCredentialConstrainer {
      * Constructs a presentation definition requiring the disclosure of some claims.
      */
     public PresentationDefinition generatePresentationDefinition(
-            String issuerVct,
+            List<String> issuerVcts,
             List<String> requiredClaims
     ) {
-        PresentationDefinition def = this.prebuildPresentationDefinition(issuerVct);
+        PresentationDefinition def = this.prebuildPresentationDefinition(issuerVcts);
 
         // Set a unique identifier
         def.setId(UUID.randomUUID().toString());
@@ -67,7 +67,7 @@ public class SdJwtCredentialConstrainer {
     /**
      * Constructs a template presentation definition specifying no claims to disclose.
      */
-    public PresentationDefinition prebuildPresentationDefinition(String issuerVct) {
+    public PresentationDefinition prebuildPresentationDefinition(List<String> issuerVcts) {
         PresentationDefinition template = new PresentationDefinition();
         template.setName(OID4VPUserAuthEndpointFactory.PROVIDER_ID);
 
@@ -83,9 +83,16 @@ public class SdJwtCredentialConstrainer {
         field.setPath(List.of(VCT_PATH));
         constraints.setFields(new ArrayList<>(List.of(field)));
 
+        List<Filter> anyOfFilters = issuerVcts.stream().map(vct -> {
+            Filter filter = new Filter();
+            filter.setType(Filter.SimpleTypes.STRING);
+            filter.setConst(vct);
+            return filter;
+        }).toList();
+
         Filter filter = new Filter();
         filter.setType(Filter.SimpleTypes.STRING);
-        filter.setConst(issuerVct);
+        filter.setAnyOf(anyOfFilters);
         field.setFilter(filter);
 
         return template;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/model/prex/Descriptor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/model/prex/Descriptor.java
@@ -172,7 +172,8 @@ public class Descriptor {
         LDP("ldp"),
         LDP_VC("ldp_vc"),
         LDP_VP("ldp_vp"),
-        VC_SD_JWT("vc+sd-jwt");
+        VC_SD_JWT("vc+sd-jwt"),
+        DC_SD_JWT("dc+sd-jwt");
         private final static Map<String, Format> CONSTANTS = new HashMap<String, Format>();
 
         static {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/service/AuthorizationRequestService.java
@@ -23,7 +23,6 @@ import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.jose.jwe.JWEUtils;
-import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.SessionExpiration;
@@ -37,6 +36,7 @@ import org.keycloak.protocol.oid4vc.oid4vp.model.ResponseMode;
 import org.keycloak.protocol.oid4vc.oid4vp.model.ResponseType;
 import org.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContext;
 import org.keycloak.protocol.oid4vc.oid4vp.model.dto.AuthorizationContextStatus;
+import org.keycloak.protocol.oid4vc.oid4vp.utils.SpacephobicJwsBuilder;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import javax.naming.ldap.LdapName;
@@ -206,7 +206,7 @@ public class AuthorizationRequestService {
                 .getEpochSecond();
         requestObject.issuedNow().exp(expiration);
 
-        return new JWSBuilder()
+        return new SpacephobicJwsBuilder()
                 .type(AUTH_REQ_JWT)
                 .x5c(List.of(getSelfSignedCertificate()))
                 .jsonContent(requestObject)

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/utils/SpacephobicJwsBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/oid4vp/utils/SpacephobicJwsBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.oid4vp.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.util.JsonSerialization;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A JWS builder that avoids adding spaces in the pre-encoded JSON.
+ *
+ * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
+ */
+public class SpacephobicJwsBuilder extends JWSBuilder {
+
+    @Override
+    protected String encodeHeader(String sigAlgName) {
+        StringBuilder builder = new StringBuilder("{");
+
+        if (org.keycloak.crypto.Algorithm.Ed25519.equals(sigAlgName) || org.keycloak.crypto.Algorithm.Ed448.equals(sigAlgName)) {
+            builder.append("\"alg\":\"").append(org.keycloak.crypto.Algorithm.EdDSA).append("\"");
+            builder.append(",\"crv\":\"").append(sigAlgName).append("\"");
+        } else {
+            builder.append("\"alg\":\"").append(sigAlgName).append("\"");
+        }
+
+        if (type != null) builder.append(",\"typ\":\"").append(type).append("\"");
+        if (kid != null) builder.append(",\"kid\":\"").append(kid).append("\"");
+        if (x5t != null) builder.append(",\"x5t\":\"").append(x5t).append("\"");
+        if (x5c != null && !x5c.isEmpty()) {
+            builder.append(",\"x5c\":[");
+            for (int i = 0; i < x5c.size(); i++) {
+                String certificate = x5c.get(i);
+                if (i > 0) {
+                    builder.append(",");
+                }
+                builder.append("\"").append(certificate).append("\"");
+            }
+            builder.append("]");
+        }
+        if (jwk != null) {
+            try {
+                builder.append(",\"jwk\":").append(JsonSerialization.mapper.writeValueAsString(jwk));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        if (contentType != null) builder.append(",\"cty\":\"").append(contentType).append("\"");
+        builder.append("}");
+        return Base64Url.encode(builder.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/oid4vp/utils/ECTestUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/oid4vp/utils/ECTestUtils.java
@@ -47,7 +47,7 @@ public class ECTestUtils {
         return jwk;
     }
 
-    static KeyWrapper getEcKeyWrapper(JWK jwk) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public static KeyWrapper getEcKeyWrapper(JWK jwk) throws NoSuchAlgorithmException, InvalidKeySpecException {
         if (jwk.getKeyType() == null || !jwk.getKeyType().equals(KeyType.EC)) {
             throw new IllegalArgumentException("Only EC keys are supported");
         }

--- a/themes/src/main/resources/theme/custom+oid4vp/.gitignore
+++ b/themes/src/main/resources/theme/custom+oid4vp/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
This PR ensures that the checks run by the Lissi wallet will eventually pass:

```cs
X509SanDns => requestObject
    .ValidateJwtSignature()
    .ValidateTrustChain()
    .ValidateSanName()
    .WithX509()
    .WithClientMetadata(clientMetadataOption),
```
Other satelite tickets are addressed.

Closes #150
Closes https://github.com/adorsys/eudiw-app/issues/488