### PR TITLE
Record login method in OIDC redirect URI to enable caller discrimination

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -90,6 +90,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
     public static final String MAX_AGE_PARAM = OAuth2Constants.MAX_AGE;
     public static final String PROMPT_PARAM = OAuth2Constants.PROMPT;
     public static final String LOGIN_HINT_PARAM = "login_hint";
+    public static final String LOGIN_METHOD_PARAM = "login_method";
     public static final String REQUEST_PARAM = "request";
     public static final String REQUEST_URI_PARAM = "request_uri";
     public static final String UI_LOCALES_PARAM = OAuth2Constants.UI_LOCALES_PARAM;
@@ -245,6 +246,11 @@ public class OIDCLoginProtocol implements LoginProtocol {
                 redirectUri.addParam(Constants.KC_ACTION, requiredActionAlias);
             }
             redirectUri.addParam(Constants.KC_ACTION_STATUS, kcActionStatus);
+        }
+
+        String kcLoginMethod = userSession.getNote(OIDCLoginProtocol.LOGIN_METHOD_PARAM);
+        if (kcLoginMethod != null) {
+            redirectUri.addParam(OIDCLoginProtocol.LOGIN_METHOD_PARAM, kcLoginMethod);
         }
 
         // Standard or hybrid flow

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -1292,6 +1292,9 @@ public class LoginActionsService {
                 authSession, null, session, realm, clientConnection, event);
         UserSessionModel freshUserSession = clientSessionCtx.getClientSession().getUserSession();
 
+        // Append note conveying this login method
+        freshUserSession.setNote(OIDCLoginProtocol.LOGIN_METHOD_PARAM, OID4VP_AUTH_LOGIN_PATH);
+
         logger.debugf("Attempting redirection after successful OID4VP authentication");
         return AuthenticationManager.redirectAfterSuccessfulFlow(
                 session, realm, freshUserSession, clientSessionCtx,

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/oid4vp/OID4VPUserAuthEndpointTest.java
@@ -60,6 +60,7 @@ import org.keycloak.protocol.oid4vc.oid4vp.model.prex.InputDescriptor;
 import org.keycloak.protocol.oid4vc.oid4vp.model.prex.PresentationDefinition;
 import org.keycloak.protocol.oid4vc.oid4vp.model.prex.PresentationSubmission;
 import org.keycloak.protocol.oid4vc.oid4vp.service.AuthorizationResponseService;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
 import org.keycloak.representations.idm.ComponentExportRepresentation;
@@ -900,6 +901,10 @@ public class OID4VPUserAuthEndpointTest extends OID4VCIssuerEndpointTest {
             String freshAuthCode = uriInfo.getQueryParameters().getFirst(OAuth2Constants.CODE);
             assertAuthenticatingUser(opts, freshAuthCode);
             assertNotEquals("New code must be issued", authCode, freshAuthCode);
+
+            // A login method param must be appended to the redirect URI
+            String loginMethod = uriInfo.getQueryParameters().getFirst(OIDCLoginProtocol.LOGIN_METHOD_PARAM);
+            assertEquals(OID4VP_AUTH_LOGIN_PATH, loginMethod);
         }
     }
 


### PR DESCRIPTION
Closes #164 

When logging in with a wallet via OpenID4VP, a param will be appended to the redirect URI specifying just that, thereby enabling the OIDC client to behave discrimatively.

```https://oidcdebugger.com/debug?state=q0hqmtqamj&session_state=69488706-0182-e07e-964d-c05b445b439a&iss=https%3A%2F%2Foryzen.duckdns.org%2Frealms%2Foid4vc-vci&login_method=oid4vp-auth-login&code=8175ab87-5158-11e6-2f0c-14e6bca390a5.69488706-0182-e07e-964d-c05b445b439a.03d607d7-3332-4e44-a69a-30d1b779ec2f```

`login_method=oid4vp-auth-login`