### PR TITLE
[OID4VCI] Conformance Test Fixes 

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -412,7 +412,9 @@ public class OID4VCIssuerEndpoint {
         String vcIssuanceFlow = clientSession.getNote(PreAuthorizedCodeGrantType.VC_ISSUANCE_FLOW);
 
         if (vcIssuanceFlow == null || !vcIssuanceFlow.equals(PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE)) {
-            AccessToken accessToken = bearerTokenAuthenticator.authenticate().token();
+            // Use getAuthResult() instead of bearerTokenAuthenticator.authenticate() directly
+            // This ensures we benefit from the cachedAuthResult caching that prevents DPoP proof reuse
+            AccessToken accessToken = getAuthResult().token();
             if (Arrays.stream(accessToken.getScope().split(" "))
                     .noneMatch(tokenScope -> tokenScope.equals(requestedCredential.getScope()))) {
                 LOGGER.debugf("Scope check failure: required scope = %s, " +

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilder.java
@@ -25,8 +25,10 @@ import org.keycloak.sdjwt.DisclosureSpec;
 import org.keycloak.sdjwt.SdJwt;
 import org.keycloak.sdjwt.SdJwtUtils;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 public class SdJwtCredentialBuilder implements CredentialBuilder {
@@ -77,6 +79,11 @@ public class SdJwtCredentialBuilder implements CredentialBuilder {
 
         // jti, nbf, iat and exp are all optional. So need to be set by a protocol mapper if needed.
         // see: https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-03.html#name-registered-jwt-claims
+        // exp is automatically set from credential scope configuration (or can be set by protocol mapper).
+        // If expirationDate is set on the VerifiableCredential, we add exp claim to the JWT.
+        Optional.ofNullable(verifiableCredential.getExpirationDate())
+                .map(Instant::getEpochSecond)
+                .ifPresent(exp -> claimSet.put("exp", exp));
 
         // Add the configured number of decoys
         if (credentialBuildConfig.getNumberOfDecoys() > 0) {


### PR DESCRIPTION
## Summary
This PR fixes multiple issues from the OID4VC conformance tests, ensuring all tests now pass for both Pre-Authorized and Authorization Code Flows.

---

### Fixes Overview

#### 1. exp Claim Not Set on Credential
- **Issue:** Missing `exp` (expiration) claim in credentials  
- **Fix:** Added automatic expiration date from credential scope configuration  
- **Result:**  Test passes

#### 2. DPoP Proof Nonce Reuse
- **Issue:** DPoP nonce could be reused within the same request  
- **Fix:** Implemented request-scoped caching to prevent reuse  
- **Result:** Test passes

#### 3. status.idx Type Mismatch
- **Issue:** `status.status_list.idx` serialized as string `"0"` instead of integer `0`  
- **Root Cause:** Conflicting statuslist plugin JAR in provider directory  
- **Fix:** Removed interfering plugin  
- **Result:** Test passes

---

### Authorization Code Flow Conformance Fix
- **Issue:** Authorization code flow failed with HTTP 500 — “DPoP proof has already been used”  
- **Root Cause:** `checkScope()` re-authenticated, bypassing DPoP cache  
- **Fix:** Updated `checkScope()` to use cached authentication result  
- **Result:** Authorization Code Flow tests now pass (HTTP 200 responses)

---

## Pre-Authorized Code Flow
- `authorization_request_type=simple`

<img width="1349" height="661" alt="Image" src="https://github.com/user-attachments/assets/550fe968-d502-49af-94ab-6ef32b8971f6" />

- `authorization_request_type=rar`

<img width="1360" height="656" alt="Image" src="https://github.com/user-attachments/assets/4a2ac927-87c4-4df1-a890-f3b12c3ab890" />


## Authorization Code Flow
- `authorization_request_type=simple`
<img width="1355" height="657" alt="Image" src="https://github.com/user-attachments/assets/c856cceb-0160-44cc-8863-ee5881a06b1e" />

- `authorization_request_type=rar`

<img width="1345" height="613" alt="Image" src="https://github.com/user-attachments/assets/2cddd846-e5d9-4f26-ad85-f8e3c25ef31d" />