### PR TITLE
Avoid OID4VCI specific code in core codebase when possible

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
@@ -19,8 +19,11 @@ package org.keycloak.protocol;
 
 import java.util.Map;
 
+import jakarta.ws.rs.WebApplicationException;
+
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
@@ -64,5 +67,22 @@ public interface LoginProtocolFactory extends ProviderFactory<LoginProtocol> {
     /**
      * Add default values to {@link ClientScopeRepresentation}s that refer to the specific login-protocol
      */
-    void addClientScopeDefaults(ClientScopeRepresentation clientModel);
+    void addClientScopeDefaults(ClientScopeRepresentation clientScope);
+
+    /**
+     * Invoked during client-scope creation or update to add additional validation hooks specific to target protocol. May throw errorResponseException in case
+     *
+     * @param session Keycloak session
+     * @param clientScope client scope to create or update
+     * @throws WebApplicationException or some of it's subclass if validation fails
+     */
+    default void validateClientScope(KeycloakSession session, ClientScopeRepresentation clientScope) throws WebApplicationException {
+    }
+
+    /**
+     * Test if the clientScope is valid for particular client. Usually called during protocol requests
+     */
+    default boolean isValidClientScope(KeycloakSession session, ClientModel client, ClientScopeModel clientScope) {
+        return true;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
@@ -122,7 +122,7 @@ public class ClientScopesResource {
         auth.clients().requireManageClientScopes();
         ClientScopeResource.validateClientScopeName(rep.getName());
         ClientScopeResource.validateClientScopeProtocol(session, rep.getProtocol());
-        ClientScopeResource.validateOid4vcProtocol(session, rep.getProtocol());
+        ClientScopeResource.validateClientScope(session, rep);
         ClientScopeResource.validateDynamicClientScope(rep);
         try {
             LoginProtocolFactory loginProtocolFactory = //

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTestOid4Vci.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTestOid4Vci.java
@@ -19,19 +19,22 @@
 package org.keycloak.tests.admin.client;
 
 import java.util.Map;
-import java.util.Optional;
 
-import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.common.Profile;
 import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.util.ApiUtil;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -62,11 +65,7 @@ public class ClientScopeTestOid4Vci extends AbstractClientScopeTest {
         String clientScopeId = null;
         try (Response response = clientScopes().create(clientScope)) {
             Assertions.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-            String location = (String) Optional.ofNullable(response.getHeaders().get(HttpHeaders.LOCATION))
-                                               .map(list -> list.get(0))
-                                               .orElse(null);
-            Assertions.assertNotNull(location);
-            clientScopeId = location.substring(location.lastIndexOf("/") + 1);
+            clientScopeId = ApiUtil.getCreatedId(response);
 
             ClientScopeRepresentation createdClientScope = clientScopes().get(clientScopeId).toRepresentation();
             Assertions.assertNotNull(createdClientScope);
@@ -101,6 +100,57 @@ public class ClientScopeTestOid4Vci extends AbstractClientScopeTest {
             Assertions.assertNotNull(clientScopeId);
             // cleanup
             clientScopes().get(clientScopeId).remove();
+        }
+    }
+
+    @DisplayName("Verify CRUD of clientScope when OID4VCI is disabled for the realm")
+    @Test
+    public void testCreateOid4vciClientScopeDisabledForTheRealm() {
+        RealmRepresentation realm = managedRealm.admin().toRepresentation();
+        try {
+            // Create clientScope1 successfully
+            String clientScopeId1;
+            ClientScopeRepresentation clientScope = new ClientScopeRepresentation();
+            clientScope.setName("test-client-scope1");
+            clientScope.setDescription("test-client-scope-description");
+            clientScope.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
+            clientScope.setAttributes(Map.of("test-attribute", "test-value"));
+            try (Response response = clientScopes().create(clientScope)) {
+                Assertions.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+                clientScopeId1 = ApiUtil.getCreatedId(response);
+            }
+
+            // Disable OID4VCI for the realm
+            realm.setVerifiableCredentialsEnabled(false);
+            managedRealm.admin().update(realm);
+
+            // Test not possible to update existing oid4vci client-scope
+            ClientScopeResource clientScope1 = managedRealm.admin().clientScopes().get(clientScopeId1);
+            ClientScopeRepresentation clientScopeRep1 = clientScope1.toRepresentation();
+            clientScopeRep1.setDescription("Foo");
+            try {
+                clientScope1.update(clientScopeRep1);
+                Assert.fail("Not expected to update client scope");
+            } catch (BadRequestException bre) {
+                // expected
+            }
+
+            // Still possible to delete oid4vci clientScope
+            clientScope1.remove();
+
+            // Not possible to create new oid4vci clientScope
+            clientScope= new ClientScopeRepresentation();
+            clientScope.setName("test-client-scope2");
+            clientScope.setDescription("test-client-scope-description");
+            clientScope.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
+            clientScope.setAttributes(Map.of("test-attribute", "test-value"));
+            try (Response response = clientScopes().create(clientScope)) {
+                Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            }
+        } finally {
+            // Revert
+            realm.setVerifiableCredentialsEnabled(true);
+            managedRealm.admin().update(realm);
         }
     }
 


### PR DESCRIPTION
I propose that we add provider specific hooks instead of `if/else` branches specific to OID4VCI protocol within core codebase classes.

Adding 2 new methods to `LoginProtocolFactory` to make sure that we can do protocol-specific validations at the protocol level rather than having this in the core.

It also optimizes performance a bit (as additional call to `TokenManager.getRequestedClientScopes` within same request could be potentially expensive as it does few other things and may call DB as well)
