### PR TITLE
Generate pre-authorized codes using the JWT format

### DIFF
--- a/common/src/main/java/org/keycloak/common/VerificationException.java
+++ b/common/src/main/java/org/keycloak/common/VerificationException.java
@@ -22,11 +22,19 @@ package org.keycloak.common;
  * @version $Revision: 1 $
  */
 public class VerificationException extends Exception {
+
+    private String errorType;
+
     public VerificationException() {
     }
 
     public VerificationException(String message) {
         super(message);
+    }
+
+    public VerificationException(String message, String errorType) {
+        super(message);
+        this.errorType = errorType;
     }
 
     public VerificationException(String message, Throwable cause) {
@@ -35,5 +43,9 @@ public class VerificationException extends Exception {
 
     public VerificationException(Throwable cause) {
         super(cause);
+    }
+
+    public String getErrorType() {
+        return errorType;
     }
 }

--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -146,7 +146,7 @@ Create a JSON file (e.g., `realm-attributes.json`) with the following content:
 ==== Attribute Breakdown
 
 The attributes section contains issuer-specific metadata:
-- **preAuthorizedCodeLifespanS** – Defines how long pre-authorized codes remain valid (in seconds). By default, these codes are issued as JWTs (with `typ` header `oid4vci-pre-auth-code+jwt`) and this lifespan controls the computation of the `exp` claim in the JWT.
+- **preAuthorizedCodeLifespanS** – Defines how long pre-authorized codes remain valid (in seconds).
 - **oid4vc.attestation.trusted_keys** – JSON array of trusted JWK (JSON Web Key) objects for attestation proof validation. Each JWK must include a `kid` (key ID) field. These keys take precedence over realm session keys when there are conflicts. Useful for configuring additional trusted keys beyond the realm's default keys. Format: JSON array of JWK objects, e.g., `[{"kid":"key1","kty":"EC",...},{"kid":"key2","kty":"RSA",...}]`.
 - **oid4vc.attestation.trusted_key_ids** – Comma-separated list of key IDs from the realm's key providers to use for attestation proof validation. Keys are looked up by their `kid` regardless of enabled status, allowing the use of disabled keys that are not exposed in well-known endpoints. This attribute takes the highest priority when merging trusted keys. Format: comma-separated list of key IDs, e.g., `key-id-1,key-id-2,key-id-3`.
 

--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -146,7 +146,7 @@ Create a JSON file (e.g., `realm-attributes.json`) with the following content:
 ==== Attribute Breakdown
 
 The attributes section contains issuer-specific metadata:
-- **preAuthorizedCodeLifespanS** – Defines how long pre-authorized codes remain valid (in seconds).
+- **preAuthorizedCodeLifespanS** – Defines how long pre-authorized codes remain valid (in seconds). By default, these codes are issued as JWTs (with `typ` header `oid4vci-pre-auth-code+jwt`) and this lifespan controls the computation of the `exp` claim in the JWT.
 - **oid4vc.attestation.trusted_keys** – JSON array of trusted JWK (JSON Web Key) objects for attestation proof validation. Each JWK must include a `kid` (key ID) field. These keys take precedence over realm session keys when there are conflicts. Useful for configuring additional trusted keys beyond the realm's default keys. Format: JSON array of JWK objects, e.g., `[{"kid":"key1","kty":"EC",...},{"kid":"key2","kty":"RSA",...}]`.
 - **oid4vc.attestation.trusted_key_ids** – Comma-separated list of key IDs from the realm's key providers to use for attestation proof validation. Keys are looked up by their `kid` regardless of enabled status, allowing the use of disabled keys that are not exposed in well-known endpoints. This attribute takes the highest priority when merging trusted keys. Format: comma-separated list of key IDs, e.g., `key-id-1,key-id-2,key-id-3`.
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
@@ -38,10 +38,10 @@ public interface CredentialOfferStorage extends Provider {
         private String clientId;
         private String userId;
         private String nonce;
-        private int expiration;
+        private long expiration;
         private OID4VCAuthorizationDetail authorizationDetails;
 
-        public CredentialOfferState(CredentialsOffer credOffer, String clientId, String userId, int expiration) {
+        public CredentialOfferState(CredentialsOffer credOffer, String clientId, String userId, long expiration) {
             this.credentialsOffer = credOffer;
             this.clientId = clientId;
             this.userId = userId;
@@ -75,7 +75,7 @@ public interface CredentialOfferStorage extends Provider {
             return nonce;
         }
 
-        public int getExpiration() {
+        public long getExpiration() {
             return expiration;
         }
 
@@ -108,7 +108,7 @@ public interface CredentialOfferStorage extends Provider {
             return this;
         }
 
-        public CredentialOfferState setExpiration(int expiration) {
+        public CredentialOfferState setExpiration(long expiration) {
             this.expiration = expiration;
             return this;
         }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
@@ -17,15 +17,13 @@
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import java.beans.Transient;
-import java.util.Optional;
+import java.util.Objects;
 
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
-import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
-import org.keycloak.protocol.oid4vc.model.PreAuthorizedGrant;
 import org.keycloak.provider.Provider;
 import org.keycloak.saml.RandomSecret;
 
@@ -52,14 +50,7 @@ public interface CredentialOfferStorage extends Provider {
         }
 
         // For json serialization
-        CredentialOfferState() {
-        }
-
-        @Transient
-        public Optional<String> getPreAuthorizedCode() {
-            return Optional.ofNullable(credentialsOffer.getGrants())
-                    .map(PreAuthorizedGrant::getPreAuthorizedCode)
-                    .map(PreAuthorizedCode::getPreAuthorizedCode);
+        public CredentialOfferState() {
         }
 
         @Transient
@@ -92,36 +83,52 @@ public interface CredentialOfferStorage extends Provider {
             return authorizationDetails;
         }
 
-        public void setAuthorizationDetails(OID4VCAuthorizationDetail authorizationDetails) {
+        public CredentialOfferState setAuthorizationDetails(OID4VCAuthorizationDetail authorizationDetails) {
             this.authorizationDetails = authorizationDetails;
+            return this;
         }
 
-        void setCredentialsOffer(CredentialsOffer credentialsOffer) {
+        public CredentialOfferState setCredentialsOffer(CredentialsOffer credentialsOffer) {
             this.credentialsOffer = credentialsOffer;
+            return this;
         }
 
-        void setClientId(String clientId) {
+        public CredentialOfferState setClientId(String clientId) {
             this.clientId = clientId;
+            return this;
         }
 
-        void setUserId(String userId) {
+        public CredentialOfferState setUserId(String userId) {
             this.userId = userId;
+            return this;
         }
 
-        void setNonce(String nonce) {
+        public CredentialOfferState setNonce(String nonce) {
             this.nonce = nonce;
+            return this;
         }
 
-        void setExpiration(int expiration) {
+        public CredentialOfferState setExpiration(int expiration) {
             this.expiration = expiration;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            CredentialOfferState that = (CredentialOfferState) o;
+            return getExpiration() == that.getExpiration() && Objects.equals(getCredentialsOffer(), that.getCredentialsOffer()) && Objects.equals(getClientId(), that.getClientId()) && Objects.equals(getUserId(), that.getUserId()) && Objects.equals(getNonce(), that.getNonce()) && Objects.equals(getAuthorizationDetails(), that.getAuthorizationDetails());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getCredentialsOffer(), getClientId(), getUserId(), getNonce(), getExpiration(), getAuthorizationDetails());
         }
     }
 
     void putOfferState(KeycloakSession session, CredentialOfferState entry);
 
     CredentialOfferState findOfferStateByNonce(KeycloakSession session, String nonce);
-
-    CredentialOfferState findOfferStateByCode(KeycloakSession session, String code);
 
     CredentialOfferState findOfferStateByCredentialId(KeycloakSession session, String credId);
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
@@ -66,9 +66,7 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
         
         String entryJson = JsonSerialization.valueAsString(entry);
         session.singleUseObjects().put(entry.getNonce(), lifespanSeconds, Map.of(ENTRY_KEY, entryJson));
-        entry.getPreAuthorizedCode().ifPresent(it -> {
-            session.singleUseObjects().put(it, lifespanSeconds, Map.of(ENTRY_KEY, entryJson));
-        });
+
         Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
             it.getCredentialIdentifiers().forEach( cid -> {
                 session.singleUseObjects().put(cid, lifespanSeconds, Map.of(ENTRY_KEY, entryJson));
@@ -86,15 +84,6 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
     }
 
     @Override
-    public CredentialOfferState findOfferStateByCode(KeycloakSession session, String code) {
-        if (session.singleUseObjects().contains(code)) {
-            String entryJson = session.singleUseObjects().get(code).get(ENTRY_KEY);
-            return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
-        }
-        return null;
-    }
-
-    @Override
     public CredentialOfferState findOfferStateByCredentialId(KeycloakSession session, String credId) {
         if (session.singleUseObjects().contains(credId)) {
             String entryJson = session.singleUseObjects().get(credId).get(ENTRY_KEY);
@@ -106,9 +95,7 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
     public void replaceOfferState(KeycloakSession session, CredentialOfferState entry) {
         String entryJson = JsonSerialization.valueAsString(entry);
         session.singleUseObjects().replace(entry.getNonce(), Map.of(ENTRY_KEY, entryJson));
-        entry.getPreAuthorizedCode().ifPresent(it -> {
-            session.singleUseObjects().replace(it, Map.of(ENTRY_KEY, entryJson));
-        });
+
         Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
             long lifespanSeconds = calculateLifespanSeconds(entry.getExpiration());
             it.getCredentialIdentifiers().forEach( cid -> {
@@ -125,9 +112,7 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
     @Override
     public void removeOfferState(KeycloakSession session, CredentialOfferState entry) {
         session.singleUseObjects().remove(entry.getNonce());
-        entry.getPreAuthorizedCode().ifPresent(it -> {
-            session.singleUseObjects().remove(it);
-        });
+
         Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
             it.getCredentialIdentifiers().forEach( cid -> {
                 session.singleUseObjects().remove(cid);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
@@ -42,7 +42,7 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
      * @param expirationTimestamp Absolute expiration timestamp in seconds
      * @return Lifespan in seconds, or 0 if the entry is already expired
      */
-    private long calculateLifespanSeconds(int expirationTimestamp) {
+    private long calculateLifespanSeconds(long expirationTimestamp) {
         int currentTime = Time.currentTime();
         long lifespan = expirationTimestamp - currentTime;
         

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
@@ -1,0 +1,267 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.crypto.SignatureVerifierContext;
+import org.keycloak.events.Errors;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.JwtPreAuthCode;
+import org.keycloak.protocol.oidc.OIDCWellKnownProviderFactory;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.utils.StringUtil;
+import org.keycloak.wellknown.WellKnownProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
+
+/**
+ * Implementation of {@link PreAuthCodeHandler} for JWT pre-authorized codes.
+ */
+public class JwtPreAuthCodeHandler implements PreAuthCodeHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtPreAuthCodeHandler.class);
+    public static final String PRE_AUTH_CODE_TYP = "oid4vci-pre-auth-code+jwt";
+
+    private final KeycloakSession session;
+    private final RealmModel realm;
+
+    public JwtPreAuthCodeHandler(KeycloakSession session) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
+    }
+
+    @Override
+    public String createPreAuthCode(CredentialOfferState offerState) {
+        // Building
+        String salt = Base64Url.encode(SecretGenerator.getInstance().randomBytes());
+        JwtPreAuthCode jwtBody = (JwtPreAuthCode) new JwtPreAuthCode()
+                .salt(salt)
+                .credentialOfferState(offerState)
+                .issuer(getCredentialIssuer())
+                .addAudience(getTokenEndpoint())
+                .issuedNow()
+                .exp((long) offerState.getExpiration());
+
+        // Signing
+        SignatureSignerContext signer = getSignerContext(offerState);
+        return new JWSBuilder()
+                .type(PRE_AUTH_CODE_TYP)
+                .jsonContent(jwtBody)
+                .sign(signer);
+    }
+
+    @Override
+    public CredentialOfferState verifyPreAuthCode(String preAuthCode) throws VerificationException {
+        // Parse the JWT
+        JWSInput jwsInput;
+        try {
+            jwsInput = new JWSInput(preAuthCode);
+        } catch (JWSInputException e) {
+            throw new VerificationException("Failed to parse pre-auth code: Not JWT", e);
+        }
+
+        // Verify JWT (Signature + claim conformance)
+        TokenVerifier<JwtPreAuthCode> verifier = TokenVerifier.create(preAuthCode, JwtPreAuthCode.class);
+        verifier.verifierContext(getVerifierContext(jwsInput.getHeader()));
+        getPropertyVerifiers(verifier).forEach(verifier::withChecks);
+        verifier.verify();
+
+        // Parse payload as JwtPreAuthCode and extract CredentialOfferState
+        try {
+            JwtPreAuthCode jwtBody = jwsInput.readJsonContent(JwtPreAuthCode.class);
+            return jwtBody.getCredentialOfferState();
+        } catch (JWSInputException e) {
+            throw new VerificationException("Failed to recover credential offer state", e);
+        }
+    }
+
+    private String getCredentialIssuer() {
+        return OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
+    }
+
+    private String getTokenEndpoint() {
+        WellKnownProvider oidcProvider = session.getProvider(
+                WellKnownProvider.class, OIDCWellKnownProviderFactory.PROVIDER_ID);
+        OIDCConfigurationRepresentation oidcConfig = (OIDCConfigurationRepresentation) oidcProvider.getConfig();
+        return oidcConfig.getTokenEndpoint();
+    }
+
+    /**
+     * Retrieves the preferred signing algorithms for JWT pre-auth codes,
+     * based on the configuration of credentials under consideration.
+     */
+    private List<String> getPreferredSigningAlgs(CredentialOfferState offerState) {
+        List<String> configIds = Optional.ofNullable(offerState)
+                .map(CredentialOfferState::getCredentialsOffer)
+                .map(CredentialsOffer::getCredentialConfigurationIds)
+                .orElse(List.of());
+
+        Stream<CredentialScopeModel> credentialScopes = session.clientScopes()
+                .getClientScopesByProtocol(realm, OID4VC_PROTOCOL)
+                .map(CredentialScopeModel::new)
+                .filter(s -> configIds.contains(
+                        s.getCredentialConfigurationId()
+                ));
+
+        return credentialScopes.map(CredentialScopeModel::getSigningAlg)
+                .filter(StringUtil::isNotBlank)
+                .distinct()
+                .toList();
+    }
+
+    /**
+     * Retrieves a SignatureSignerContext for signing JWT pre-auth codes, based on the preferred
+     * signing algorithms derived from the credential offer state.
+     */
+    private SignatureSignerContext getSignerContext(CredentialOfferState offerState) {
+        List<String> preferredAlgs = getPreferredSigningAlgs(offerState);
+        logger.debug("Preferred signing algorithms for JWT pre-auth code: {}", preferredAlgs);
+        for (String alg : preferredAlgs) {
+            try {
+                return getSignerContext(alg);
+            } catch (RuntimeException ignored) {
+                logger.debug("No active signing key/context found for algorithm {}, skipping", alg);
+            }
+        }
+
+        // Default to Algorithm.ES256 if no preferred algorithm is found or signing key available
+        logger.debug("Falling back to default algorithm {} for signing JWT pre-auth codes", Algorithm.ES256);
+        return getSignerContext(Algorithm.ES256);
+    }
+
+    /**
+     * Retrieves the SignatureSignerContext associated with the given algorithm.
+     */
+    private SignatureSignerContext getSignerContext(String alg) {
+        KeyWrapper signingKey = session.keys().getActiveKey(realm, KeyUse.SIG, alg);
+        if (signingKey == null) {
+            throw new IllegalArgumentException(String.format("No active signing key found for algorithm %s", alg));
+        }
+
+        SignatureProvider signatureProvider = session.getProvider(
+                SignatureProvider.class,
+                signingKey.getAlgorithm());
+
+        return signatureProvider.signer(signingKey);
+    }
+
+    /**
+     * Retrieves a SignatureVerifierContext for verifying JWT pre-auth codes,
+     * based on signing metadata in the JWS header and available keys.
+     */
+    private SignatureVerifierContext getVerifierContext(JWSHeader jwsHeader) throws VerificationException {
+        String kid = jwsHeader.getKeyId();
+        String alg = jwsHeader.getAlgorithm().toString();
+        KeyWrapper key = session.keys().getKey(realm, kid, KeyUse.SIG, alg);
+
+        if (key == null) {
+            throw new VerificationException(String.format(
+                    "No key found for verifying JWT pre-auth code with alg '%s' and kid '%s'",
+                    alg, kid));
+        }
+
+        SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, key.getAlgorithm());
+        return signatureProvider.verifier(key);
+    }
+
+    /**
+     * Property verifiers.
+     */
+    private List<TokenVerifier.Predicate<JwtPreAuthCode>> getPropertyVerifiers(TokenVerifier<JwtPreAuthCode> verifier) {
+        TokenVerifier.Predicate<JwtPreAuthCode> typCheck = jwt -> {
+            JWSHeader header = verifier.getHeader();
+            String typ = Optional.ofNullable(header)
+                    .map(JWSHeader::getType)
+                    .orElse(null);
+
+            if (!PRE_AUTH_CODE_TYP.equals(typ)) {
+                throw new VerificationException(String.format(
+                        "Invalid or missing JWT typ header for pre-auth code: expected '%s' got '%s'",
+                        PRE_AUTH_CODE_TYP, typ));
+            }
+
+            return true;
+        };
+
+        TokenVerifier.Predicate<JwtPreAuthCode> offerStateCheck = jwt -> {
+            if (jwt.getCredentialOfferState() == null
+                    || jwt.getCredentialOfferState().getCredentialsOffer() == null) {
+                throw new VerificationException("Not a jwt pre-auth code: no credential offer state found");
+            }
+
+            return true;
+        };
+
+        TokenVerifier.Predicate<JwtPreAuthCode> issuerCheck = jwt -> {
+            String expectedIssuer = getCredentialIssuer();
+            if (!expectedIssuer.equals(jwt.getIssuer())) {
+                String message = String.format(
+                        "Unexpected issuer of jwt pre-auth code: %s (expected) != %s (actual)",
+                        expectedIssuer, jwt.getIssuer());
+                throw new VerificationException(message);
+            }
+            return true;
+        };
+
+        TokenVerifier.Predicate<JwtPreAuthCode> audienceCheck = jwt -> {
+            String expectedAudience = getTokenEndpoint();
+            List<String> actualAudiences = Optional.ofNullable(jwt.getAudience())
+                    .map(Arrays::asList)
+                    .orElse(List.of());
+
+            if (actualAudiences.isEmpty() || !actualAudiences.contains(expectedAudience)) {
+                String message = String.format(
+                        "Invalid audience of jwt pre-auth code: %s (expected) not in %s (actual)",
+                        expectedAudience, actualAudiences);
+                throw new VerificationException(message);
+            }
+
+            return true;
+        };
+
+        TokenVerifier.Predicate<JwtPreAuthCode> expirationCheck = jwt -> {
+            Long exp = jwt.getExp();
+            if (exp == null) {
+                throw new VerificationException("Jwt pre-auth code has no expiration time");
+            }
+
+            long now = Time.currentTime();
+            if (exp < now) {
+                String message = String.format("Jwt pre-auth code not valid: %s (exp) < %s (now)", exp, now);
+                throw new VerificationException(message, Errors.EXPIRED_CODE);
+            }
+
+            return true;
+        };
+
+        return List.of(typCheck, offerStateCheck, issuerCheck, audienceCheck, expirationCheck);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerFactory.java
@@ -1,0 +1,19 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.models.KeycloakSession;
+
+public class JwtPreAuthCodeHandlerFactory implements PreAuthCodeHandlerFactory {
+
+    public static final String PROVIDER_ID = "jwt-pre-auth-code-handler";
+
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public JwtPreAuthCodeHandler create(KeycloakSession session) {
+        return new JwtPreAuthCodeHandler(session);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandler.java
@@ -1,0 +1,23 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.common.VerificationException;
+import org.keycloak.provider.Provider;
+
+import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
+
+/**
+ * Handles the production and verification of pre-authorized codes.
+ */
+public interface PreAuthCodeHandler extends Provider {
+
+    /**
+     * Generates a pre-authorized code for the given credential offer state (only non-sensitive fields).
+     * The implementation is responsible for storing any necessary state to be recovered with verification.
+     */
+    String createPreAuthCode(CredentialOfferState offerState);
+
+    /**
+     * Verifies the given pre-authorized code and returns the associated credential offer state if valid.
+     */
+    CredentialOfferState verifyPreAuthCode(String preAuthCode) throws VerificationException;
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerFactory.java
@@ -1,0 +1,20 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderFactory;
+
+public interface PreAuthCodeHandlerFactory extends ProviderFactory<PreAuthCodeHandler> {
+
+    @Override
+    default void init(Config.Scope config) {
+    }
+
+    @Override
+    default void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    default void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerSpi.java
@@ -1,0 +1,33 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+/**
+ * SPI for handling the production and verification of pre-authorized codes.
+ */
+public class PreAuthCodeHandlerSpi implements Spi {
+
+    private static final String NAME = "preAuthCodeHandler";
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return PreAuthCodeHandler.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<PreAuthCodeHandler>> getProviderFactoryClass() {
+        return PreAuthCodeHandlerFactory.class;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
@@ -49,8 +49,7 @@ import org.keycloak.protocol.oid4vc.model.JwtCNonce;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.saml.RandomSecret;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 /**
  * @author Pascal Knüppel
@@ -63,7 +62,7 @@ public class JwtCNonceHandler implements CNonceHandler {
 
     public static final int NONCE_LENGTH_RANDOM_OFFSET = 15;
 
-    private static final Logger logger = LoggerFactory.getLogger(JwtCNonceHandler.class);
+    private static final Logger logger = Logger.getLogger(JwtCNonceHandler.class);
 
     private final KeycloakSession keycloakSession;
 
@@ -189,7 +188,7 @@ public class JwtCNonceHandler implements CNonceHandler {
         try {
             signingKey = keycloakSession.keys().getActiveKey(realm, KeyUse.SIG, Algorithm.ES256);
         } catch (RuntimeException ex) {
-            logger.debug("Failed to find active ES256 signing key for realm {}. Falling back to RSA...",
+            logger.debugf("Failed to find active ES256 signing key for realm %s. Falling back to RSA...",
                          realm.getName());
             logger.debug(ex.getMessage(), ex);
             // use RSA only as fallback since the preferred algorithm by OpenID4VC is elliptic curve

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
@@ -34,8 +34,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialSubject;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.provider.ProviderConfigProperty;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 /**
  * Map issuance date to the credential, under the default claim name "iat"
@@ -62,7 +61,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
     public static final String VALUE_SOURCE = "valueSource";
 
     private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
-    private static final Logger log = LoggerFactory.getLogger(OID4VCIssuedAtTimeClaimMapper.class);
+    private static final Logger log = Logger.getLogger(OID4VCIssuedAtTimeClaimMapper.class);
 
     static {
         ProviderConfigProperty subjectPropertyNameConfig = new ProviderConfigProperty();
@@ -112,7 +111,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
         List<String> attributePath = getMetadataAttributePath();
         String propertyName = attributePath.get(attributePath.size() - 1);
         if (propertyName == null) {
-            log.error("Invalid configuration: missing config-property '{}' for mapper '{}' of type '{}'. Mapper is ignored.",
+            log.errorf("Invalid configuration: missing config-property '%s' for mapper '%s' of type '%s'. Mapper is ignored.",
                       CLAIM_NAME,
                       mapperModel.getName(),
                       MAPPER_ID);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/DisplayObject.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/DisplayObject.java
@@ -30,8 +30,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 /**
  * Represents a DisplayObject, as used in the OID4VCI Credentials Issuer Metadata
@@ -47,7 +46,7 @@ import org.slf4j.LoggerFactory;
 )
 public class DisplayObject {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DisplayObject.class);
+    private static final Logger LOGGER = Logger.getLogger(DisplayObject.class);
 
     @JsonIgnore
     private static final String NAME_KEY = "name";
@@ -97,7 +96,7 @@ public class DisplayObject {
             // lets say we have an invalid value we should not kill the whole execution if just the display value is
             // broken
             LOGGER.debug(e.getMessage(), e);
-            LOGGER.warn("Failed to parse display-metadata for credential '{}': {}", credentialScope.getName(), e.getMessage());
+            LOGGER.warnf("Failed to parse display-metadata for credential '%s': %s", credentialScope.getName(), e.getMessage());
             return null;
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/JwtPreAuthCode.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/JwtPreAuthCode.java
@@ -1,0 +1,40 @@
+package org.keycloak.protocol.oid4vc.model;
+
+import org.keycloak.representations.JsonWebToken;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
+
+/**
+ * Payloads for JWT pre-authorized codes for OpenID4VCI.
+ * They embed a partial, public view of the credential offer state.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JwtPreAuthCode extends JsonWebToken {
+
+    @JsonProperty("credentialOfferState")
+    private CredentialOfferState credentialOfferState;
+
+    @JsonProperty("salt")
+    private String salt;
+
+    public CredentialOfferState getCredentialOfferState() {
+        return credentialOfferState;
+    }
+
+    public JwtPreAuthCode credentialOfferState(CredentialOfferState credentialOfferState) {
+        this.credentialOfferState = credentialOfferState;
+        return this;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public JwtPreAuthCode salt(String salt) {
+        this.salt = salt;
+        return this;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -59,8 +59,8 @@ import org.keycloak.utils.MediaType;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.events.Details.REASON;
-import static org.keycloak.protocol.oid4vc.model.ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION;
 import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
+import static org.keycloak.protocol.oid4vc.model.ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION;
 import static org.keycloak.services.util.DefaultClientSessionContext.fromClientSessionAndScopeParameter;
 
 public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -17,26 +17,34 @@
 
 package org.keycloak.protocol.oidc.grants;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
+import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakUriInfo;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.utils.OID4VCUtil;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -52,6 +60,7 @@ import org.jboss.logging.Logger;
 
 import static org.keycloak.events.Details.REASON;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION;
+import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
 import static org.keycloak.services.util.DefaultClientSessionContext.fromClientSessionAndScopeParameter;
 
 public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
@@ -85,15 +94,9 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                     errorMessage, Response.Status.BAD_REQUEST);
         }
 
-        var offerStorage = session.getProvider(CredentialOfferStorage.class);
-        var offerState = offerStorage.findOfferStateByCode(session, code);
-        if (offerState == null) {
-            var errorMessage = "No credential offer state for code: " + code;
-            event.detail(REASON, errorMessage).error(Errors.INVALID_CODE);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
-                    errorMessage, Response.Status.BAD_REQUEST);
-        }
-
+        // Verify the pre-auth code and retrieve the associated credential offer state.
+        // The verification logic is delegated to the configured PreAuthCodeHandler provider.
+        CredentialOfferState offerState = verifyPreAuthCode(code);
         if (offerState.isExpired()) {
             event.error(Errors.EXPIRED_CODE);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
@@ -175,7 +178,8 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         }
 
         // Add authorization_details to the OfferState and otherClaims
-        OID4VCAuthorizationDetail authDetails = (OID4VCAuthorizationDetail) authorizationDetailsResponses.get(0);
+        var offerStorage = session.getProvider(CredentialOfferStorage.class);
+        var authDetails = (OID4VCAuthorizationDetail) authorizationDetailsResponses.get(0);
         offerState.setAuthorizationDetails(authDetails);
         offerStorage.replaceOfferState(session, offerState);
 
@@ -244,7 +248,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
     public boolean isTokenAllowed(KeycloakSession session, AccessToken token) {
         // Check if the request path ends with the credential endpoint path
         boolean isCredentialEndpoint = Optional.ofNullable(session.getContext().getUri())
-                .map(uri -> uri.getPath())
+                .map(KeycloakUriInfo::getPath)
                 .map(path -> path.endsWith("/" + OID4VCIssuerEndpoint.CREDENTIAL_PATH))
                 .orElse(false);
 
@@ -257,5 +261,53 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         String expectedAudience = OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(session.getContext());
         String[] audiences = token.getAudience();
         return audiences != null && audiences.length == 1 && expectedAudience.equals(audiences[0]);
+    }
+
+    /**
+     * Runs the pre-auth code verification logic using the configured PreAuthCodeHandler provider.
+     * A public, partial view of the CredentialOfferState is returned upon successful verification.
+     */
+    private CredentialOfferState verifyPreAuthCode(String code) {
+        PreAuthCodeHandler preAuthCodeHandler = session.getProvider(PreAuthCodeHandler.class);
+        if (preAuthCodeHandler == null) {
+            throw new IllegalStateException("No PreAuthCodeHandler provider available");
+        }
+
+        CredentialOfferState offerState;
+        try {
+            offerState = preAuthCodeHandler.verifyPreAuthCode(code);
+        } catch (VerificationException e) {
+            String errorType = Optional.ofNullable(e.getErrorType()).orElse(Errors.INVALID_CODE);
+            String errorMessage = String.format("Pre-authorized code failed handler verification (%s)", errorType);
+            LOGGER.error(errorMessage, e);
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors,
+                    errorType.equals(Errors.INVALID_CODE)
+                            ? OAuthErrorException.INVALID_REQUEST
+                            : OAuthErrorException.EXPIRED_TOKEN,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        // Pre-auth code is valid, but let's prevent replay attacks
+        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
+        String key = getPreAuthCodeSingleObjectKey(code);
+        if (singleUseStore.get(key) != null) {
+            String errorMessage = "Pre-authorized code has already been used";
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        // Prevent code replay for the remaining validity period
+        long expiresIn = offerState.getExpiration() - Time.currentTime();
+        singleUseStore.put(key, expiresIn, Map.of());
+
+        return offerState;
+    }
+
+    private static String getPreAuthCodeSingleObjectKey(String code) {
+        String hash = HashUtils.sha256UrlEncodedHash(code.trim(), StandardCharsets.UTF_8);
+        String fqcn = PreAuthorizedCodeGrantType.class.getName().toLowerCase();
+        return fqcn + "." + hash;
     }
 }

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandlerFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandlerFactory
@@ -1,0 +1,1 @@
+org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandlerFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -33,6 +33,7 @@ org.keycloak.services.resources.admin.ext.AdminRealmResourceSpi
 org.keycloak.theme.freemarker.FreeMarkerSPI
 org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderSpi
 org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorageSpi
+org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandlerSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidatorSpi
 org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.CNonceHandlerSpi

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
@@ -32,6 +32,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.client.resources.TestingResource;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
@@ -52,31 +53,52 @@ import static org.junit.Assert.assertEquals;
 public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
 
     private CloseableHttpClient httpClient;
+    private TestingResource testingResource;
 
     @Before
     public void setup() {
         httpClient = HttpClientBuilder.create().build();
+        testingResource = getTestingClient().testing(TEST_REALM_NAME);
     }
 
     @Test
-    public void testPreAuthorizedGrant() throws Exception {
+    public void testPreAuthorizedGrant() {
         String userSessionId = getUserSession();
-        String preAuthorizedCode = getTestingClient().testing().getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() + 30);
+        String preAuthorizedCode = testingResource.getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() + 30);
         AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
 
         assertEquals("An access token should have successfully been returned.", HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
     }
 
     @Test
-    public void testPreAuthorizedGrantExpired() throws Exception {
+    public void testPreAuthorizedGrantExpired() {
         String userSessionId = getUserSession();
-        String preAuthorizedCode = getTestingClient().testing().getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() - 30);
+        String preAuthorizedCode = testingResource.getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() - 30);
         AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
         assertEquals("An expired code should not get an access token.", HttpStatus.SC_BAD_REQUEST, accessTokenResponse.getStatusCode());
+        assertEquals("Pre-authorized code failed handler verification (expired_code)",
+                accessTokenResponse.getErrorDescription());
     }
 
     @Test
-    public void testPreAuthorizedGrantInvalidCode() throws Exception {
+    public void testPreAuthorizedGrantReplayed() {
+        String userSessionId = getUserSession();
+        String preAuthorizedCode = testingResource.getPreAuthorizedCode(
+                TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() + 30);
+
+        AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
+        assertEquals("An access token should have successfully been returned.",
+                HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
+
+        AccessTokenResponse replayedAccessTokenResponse = postCode(preAuthorizedCode);
+        assertEquals("A replayed code should not get an access token.",
+                HttpStatus.SC_BAD_REQUEST, replayedAccessTokenResponse.getStatusCode());
+        assertEquals("Pre-authorized code has already been used",
+                replayedAccessTokenResponse.getErrorDescription());
+    }
+
+    @Test
+    public void testPreAuthorizedGrantInvalidCode() {
         // assure that a session exists.
         getUserSession();
         AccessTokenResponse accessTokenResponse = postCode("invalid-code");
@@ -102,7 +124,7 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
      * grant (used by OID4VCI flows) must be rejected with 403 Forbidden.
      */
     @Test
-    public void testPreAuthorizedGrantRealmDisabled() throws Exception {
+    public void testPreAuthorizedGrantRealmDisabled() {
         // Disable verifiable credentials for the test realm
         RealmRepresentation realmRep = adminClient.realm(TEST_REALM_NAME).toRepresentation();
         realmRep.setVerifiableCredentialsEnabled(false);
@@ -124,15 +146,11 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
         }
     }
 
-    private AccessTokenResponse postCode(String preAuthorizedCode) throws Exception {
-        HttpPost post = new HttpPost(getTokenEndpoint());
-        List<NameValuePair> parameters = new LinkedList<>();
-        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
-        parameters.add(new BasicNameValuePair("pre-authorized_code", preAuthorizedCode));
-        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
-        post.setEntity(formEntity);
-
-        return new AccessTokenResponse(httpClient.execute(post));
+    private AccessTokenResponse postCode(String preAuthorizedCode) {
+        return oauth.oid4vc()
+                .preAuthorizedCodeGrantRequest(preAuthorizedCode)
+                .endpoint(getTokenEndpoint())
+                .send();
     }
 
     private String getTokenEndpoint() {
@@ -165,6 +183,4 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
             testRealm.setUsers(List.of(user));
         }
     }
-
-
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -33,6 +34,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.client.resources.TestingResource;
+import org.keycloak.testsuite.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandlerTest;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
@@ -64,9 +66,12 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testPreAuthorizedGrant() {
         String userSessionId = getUserSession();
-        String preAuthorizedCode = testingResource.getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() + 30);
-        AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
 
+        String preAuthorizedCode = testingResource.getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() + 30);
+        // The generated pre-auth code should have been signed with an ES256 key generated on the fly
+        JwtPreAuthCodeHandlerTest.assertValidPreAuthCodeJwt(preAuthorizedCode, Algorithm.ES256);
+
+        AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
         assertEquals("An access token should have successfully been returned.", HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerTest.java
@@ -29,7 +29,6 @@ import org.apache.http.HttpStatus;
 import org.junit.Test;
 
 import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
-import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandler.PRE_AUTH_CODE_TYP;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -112,8 +111,8 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerEndpointTest {
             VerificationException exception = assertThrows(VerificationException.class,
                     () -> handler.verifyPreAuthCode(imposterPreAuthCode));
 
-            assertEquals("Invalid or missing JWT typ header for pre-auth code: " +
-                    "expected 'oid4vci-pre-auth-code+jwt' got 'null'", exception.getMessage());
+            assertEquals("Not a jwt pre-auth code: no credential offer state found",
+                    exception.getMessage());
         });
 
         // Ensure that it cannot be exchanged for an access token
@@ -222,7 +221,6 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerEndpointTest {
             throw new RuntimeException(e);
         }
 
-        assertEquals("Must be of type PreAuthCode", PRE_AUTH_CODE_TYP, jws.getHeader().getType());
         assertEquals("Must use expected signing algorithm",
                 expectedAlg, jws.getHeader().getAlgorithm().toString());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerTest.java
@@ -191,12 +191,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerEndpointTest {
     }
 
     private void configureCredentialSigningAlgorithm(ClientScopeRepresentation clientScope, String alg) {
-        if (alg == null) {
-            clientScope.getAttributes().remove(CredentialScopeModel.SIGNING_ALG);
-        } else {
-            clientScope.getAttributes().put(CredentialScopeModel.SIGNING_ALG, alg);
-        }
-
+        clientScope.getAttributes().put(CredentialScopeModel.SIGNING_ALG, alg);
         testRealm().clientScopes().get(clientScope.getId()).update(clientScope);
     }
 
@@ -210,7 +205,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerEndpointTest {
                 .send();
     }
 
-    private static void assertValidPreAuthCodeJwt(String jwt, String expectedAlg) {
+    public static void assertValidPreAuthCodeJwt(String jwt, String expectedAlg) {
         JWSInput jws;
         JwtPreAuthCode payload;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerTest.java
@@ -1,0 +1,232 @@
+package org.keycloak.testsuite.oid4vc.issuance.credentialoffer.preauth;
+
+import java.util.List;
+
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.ECDSASignatureSignerContext;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandler;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.JwtPreAuthCode;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.testsuite.oid4vc.issuance.signing.OID4VCIssuerEndpointTest;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.util.JsonSerialization;
+
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
+import static org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandler.PRE_AUTH_CODE_TYP;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerEndpointTest {
+
+    @Test
+    public void shouldGenerateValidPreAuthCode() {
+        // Initiate the flow by creating a credential offer state
+        String offerStateJson = createPreAuthOffer(null);
+
+        // Create a pre-auth code for the offer state
+        String preAuthorizedCode = testingClient.server(TEST_REALM_NAME).fetch((session) -> {
+            JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+            CredentialOfferState offerState = JsonSerialization.valueFromString(
+                    offerStateJson, CredentialOfferState.class);
+
+            // Create pre-auth code and quickly check that it is a well-structured JWT
+            String preAuthCode = handler.createPreAuthCode(offerState);
+            assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+
+            // Verify pre-auth code and recover offer state
+            try {
+                CredentialOfferState recoveredOfferState = handler.verifyPreAuthCode(preAuthCode);
+                assertEquals("Recovered offer state must match original", offerState, recoveredOfferState);
+                return preAuthCode;
+            } catch (VerificationException e) {
+                throw new RuntimeException(e);
+            }
+        }, String.class);
+
+        // Ensure that the pre-auth code can be exchanged for an access token
+        AccessTokenResponse accessTokenResponse = exchangePreAuthCodeForAccessToken(preAuthorizedCode);
+        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
+        assertNotNull("Access token must not be null", accessTokenResponse.getAccessToken());
+    }
+
+    @Test
+    public void shouldGenerateValidPreAuthCode_SignedWithPreferredAlg() {
+        // Initiate the flow by creating a credential offer state
+        String offerStateJson = createPreAuthOffer(Algorithm.RS256);
+
+        // Create a pre-auth code for the offer state and assert that it is signed with
+        // the preferred algorithm RS256 instead of the default ES256
+        testingClient.server(TEST_REALM_NAME).run((session) -> {
+            JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+            CredentialOfferState offerState = JsonSerialization.valueFromString(
+                    offerStateJson, CredentialOfferState.class);
+
+            // Create pre-auth code and quickly check that it is a well-structured JWT
+            String preAuthCode = handler.createPreAuthCode(offerState);
+            assertValidPreAuthCodeJwt(preAuthCode, Algorithm.RS256);
+        });
+    }
+
+    @Test
+    public void mustRejectNonPreAuthCodeJwts() {
+        // Get a valid but not pre-auth code JWT
+        String imposterPreAuthCode = testingClient.server(TEST_REALM_NAME).fetch((session) -> {
+            // Build a random JWT
+            JsonWebToken jwt = new JsonWebToken()
+                    .issuer("issuer")
+                    .addAudience("audience")
+                    .issuedNow()
+                    .exp((long) (Time.currentTime() + 60));
+
+            // Sign to yield a valid JWT
+            RealmModel realm = session.getContext().getRealm();
+            KeyWrapper keyWrapper = session.keys().getActiveKey(realm, KeyUse.SIG, Algorithm.ES256);
+            ECDSASignatureSignerContext signer = new ECDSASignatureSignerContext(keyWrapper);
+            return new JWSBuilder().jsonContent(jwt).sign(signer);
+        }, String.class);
+
+        // Ensure that it fails handler verification
+        testingClient.server(TEST_REALM_NAME).run((session) -> {
+            JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+
+            VerificationException exception = assertThrows(VerificationException.class,
+                    () -> handler.verifyPreAuthCode(imposterPreAuthCode));
+
+            assertEquals("Invalid or missing JWT typ header for pre-auth code: " +
+                    "expected 'oid4vci-pre-auth-code+jwt' got 'null'", exception.getMessage());
+        });
+
+        // Ensure that it cannot be exchanged for an access token
+        AccessTokenResponse accessTokenResponse = exchangePreAuthCodeForAccessToken(imposterPreAuthCode);
+        assertEquals(HttpStatus.SC_BAD_REQUEST, accessTokenResponse.getStatusCode());
+        assertEquals("Pre-authorized code failed handler verification (invalid_code)",
+                accessTokenResponse.getErrorDescription());
+    }
+
+    @Test
+    public void mustRejectExpiredPreAuthCodeJwts() {
+        // Initiate the flow by creating a credential offer state
+        String offerStateJson = createPreAuthOffer(null);
+
+        // Assert that an expired pre-auth code fails verification
+        testingClient.server(TEST_REALM_NAME).run((session) -> {
+            JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+            CredentialOfferState offerState = JsonSerialization.valueFromString(
+                    offerStateJson, CredentialOfferState.class);
+            String preAuthCode = handler.createPreAuthCode(offerState);
+
+            try {
+                Time.setOffset(120); // Move time forward to ensure code is expired
+                VerificationException exception = assertThrows(VerificationException.class,
+                        () -> handler.verifyPreAuthCode(preAuthCode));
+                assertTrue(exception.getMessage().startsWith("Jwt pre-auth code not valid:"));
+            } finally {
+                Time.setOffset(0);
+            }
+        });
+    }
+
+    @Test
+    public void mustRejectReplayedPreAuthCodeJwts() {
+        // Initiate the flow by creating a credential offer state
+        String offerStateJson = createPreAuthOffer(null);
+
+        // Create a pre-auth code for the offer state
+        String preAuthorizedCode = testingClient.server(TEST_REALM_NAME).fetch((session) -> {
+            JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+            CredentialOfferState offerState = JsonSerialization.valueFromString(
+                    offerStateJson, CredentialOfferState.class);
+
+            // Create pre-auth code and quickly check that it is a well-structured JWT
+            String preAuthCode = handler.createPreAuthCode(offerState);
+            assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+            return preAuthCode;
+        }, String.class);
+
+        // First use: the pre-auth code can be exchanged for an access token
+        AccessTokenResponse accessTokenResponse = exchangePreAuthCodeForAccessToken(preAuthorizedCode);
+        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
+
+        // Second use: the same pre-auth code must be rejected as replayed
+        AccessTokenResponse replayResponse = exchangePreAuthCodeForAccessToken(preAuthorizedCode);
+        assertEquals(HttpStatus.SC_BAD_REQUEST, replayResponse.getStatusCode());
+        assertEquals("Pre-authorized code has already been used",
+                replayResponse.getErrorDescription());
+    }
+
+    private String createPreAuthOffer(String signingAlg) {
+        // Configure signing algorithm in credential client scope
+        configureCredentialSigningAlgorithm(sdJwtTypeCredentialClientScope, signingAlg);
+
+        return testingClient.server(TEST_REALM_NAME).fetchString((session) -> {
+            CredentialsOffer credOffer = new CredentialsOffer()
+                    .setCredentialIssuer(OID4VCIssuerWellKnownProvider.getIssuer(session.getContext()))
+                    .setCredentialConfigurationIds(List.of(sdJwtTypeCredentialConfigurationIdName));
+
+            RealmModel realm = session.getContext().getRealm();
+            UserModel user = session.users().getUserByUsername(realm, "john");
+
+            return new CredentialOfferState(
+                    credOffer, "test-app", user.getId(), Time.currentTime() + 60);
+        });
+    }
+
+    private void configureCredentialSigningAlgorithm(ClientScopeRepresentation clientScope, String alg) {
+        if (alg == null) {
+            clientScope.getAttributes().remove(CredentialScopeModel.SIGNING_ALG);
+        } else {
+            clientScope.getAttributes().put(CredentialScopeModel.SIGNING_ALG, alg);
+        }
+
+        testRealm().clientScopes().get(clientScope.getId()).update(clientScope);
+    }
+
+    private AccessTokenResponse exchangePreAuthCodeForAccessToken(String preAuthCode) {
+        final String endpoint = getRealmPath(TEST_REALM_NAME);
+        OIDCConfigurationRepresentation oidcConfig = getAuthorizationMetadata(endpoint);
+
+        return oauth.oid4vc()
+                .preAuthorizedCodeGrantRequest(preAuthCode)
+                .endpoint(oidcConfig.getTokenEndpoint())
+                .send();
+    }
+
+    private static void assertValidPreAuthCodeJwt(String jwt, String expectedAlg) {
+        JWSInput jws;
+        JwtPreAuthCode payload;
+
+        try {
+            jws = new JWSInput(jwt);
+            payload = jws.readJsonContent(JwtPreAuthCode.class);
+        } catch (JWSInputException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertEquals("Must be of type PreAuthCode", PRE_AUTH_CODE_TYP, jws.getHeader().getType());
+        assertEquals("Must use expected signing algorithm",
+                expectedAlg, jws.getHeader().getAlgorithm().toString());
+
+        assertNotNull("Must embed a credential offer state", payload.getCredentialOfferState());
+        assertNotNull("Must be salted", payload.getSalt());
+    }
+}


### PR DESCRIPTION
Related to https://github.com/keycloak/keycloak/issues/45231
Closes #237 

Sample

```json
{
  "header" : {
    "alg" : "ES256",
    "typ" : "oid4vci-pre-auth-code+jwt",
    "kid" : "JEqmduqZ0gbf-qDY3KfYJwNbEvpcCjmz6BNmraPkWws"
  },
  "payload" : {
    "exp" : 1771319783,
    "iat" : 1771319753,
    "iss" : "https://localhost:8543/auth/realms/test",
    "aud" : "https://localhost:8543/auth/realms/test/protocol/openid-connect/token",
    "credentialOfferState" : {
      "credentialsOffer" : {
        "credential_issuer" : "https://localhost:8543/auth/realms/test",
        "credential_configuration_ids" : [ "sd-jwt-credential-config-id" ]
      },
      "clientId" : "test-app",
      "userId" : "4a5fad5d-180c-4c9b-808a-44bb3ef06030",
      "nonce" : "zs5jonZqJbg7NyW2GcGRMEAikBjNfPN86OtKdjboQ2UfHXELGp9jRBFX-4oLPo6D1G2ObPCAVniyrgIOso3Zeg",
      "expiration" : 1771319783
    },
    "salt" : "Xa4G62rupli3cFLng_hBM9m65x91hhMpZFgJPu5sQLU"
  },
  "signature" : "862DAzi76JyD2TfXggufVR43AKQYJo0QlV2-fI1cqmIDN23ckeZ-qgI_RPoEOgShjs4WvVuyT7rKa3W8bGQD5w"
}
```