### PR TITLE
[OID4VCI] Disable `ldp_vc` format and providers to focus on JWT VC and SD-JWT VC

### DIFF
--- a/core/src/main/java/org/keycloak/VCFormat.java
+++ b/core/src/main/java/org/keycloak/VCFormat.java
@@ -39,21 +39,17 @@ public interface VCFormat {
      */
     String SD_JWT_VC = "dc+sd-jwt";
 
-    // [TODO #44875] Proof Type null is not supported for format ldp_vc
-    // https://github.com/keycloak/keycloak/issues/44875
     String[] SUPPORTED_FORMATS = new String[]{JWT_VC, SD_JWT_VC};
 
     static String getFromScope(String scope) {
         String format = SD_JWT_VC; // default format
         if (scope.toLowerCase().endsWith("_jwt")) format = JWT_VC;
-        else if (scope.toLowerCase().endsWith("_ld")) format = LDP_VC;
         return format;
     }
 
     static String getScopeSuffix(String value) {
         String suffix = "";
         if (JWT_VC.equals(value)) suffix = "_jwt";
-        else if (LDP_VC.equals(value)) suffix = "_ld";
         else if (SD_JWT_VC.equals(value)) suffix = "_sd";
         return suffix;
     }

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderFactory
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
-org.keycloak.protocol.oid4vc.issuance.credentialbuilder.LDCredentialBuilderFactory
+# Disabled to keep OID4VCI scope limited to supported formats (JWT VC and SD-JWT VC).
+# org.keycloak.protocol.oid4vc.issuance.credentialbuilder.LDCredentialBuilderFactory
 org.keycloak.protocol.oid4vc.issuance.credentialbuilder.JwtCredentialBuilderFactory
 org.keycloak.protocol.oid4vc.issuance.credentialbuilder.SdJwtCredentialBuilderFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerFactory
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
-org.keycloak.protocol.oid4vc.issuance.signing.LDCredentialSignerFactory
+# Disabled to keep OID4VCI scope limited to supported formats (JWT VC and SD-JWT VC).
+# org.keycloak.protocol.oid4vc.issuance.signing.LDCredentialSignerFactory
 org.keycloak.protocol.oid4vc.issuance.signing.JwtCredentialSignerFactory
 org.keycloak.protocol.oid4vc.issuance.signing.SdJwtCredentialSignerFactory

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
@@ -8,10 +8,9 @@ import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.common.profile.CommaSeparatedListProfileConfigResolver;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.signing.CredentialSigner;
 import org.keycloak.services.resteasy.ResteasyKeycloakSession;
 import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
-
-import org.keycloak.protocol.oid4vc.issuance.signing.CredentialSigner;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
@@ -11,11 +11,14 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.resteasy.ResteasyKeycloakSession;
 import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
 
+import org.keycloak.protocol.oid4vc.issuance.signing.CredentialSigner;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -47,5 +50,23 @@ public class CredentialBuilderFactoryTest {
         for (CredentialBuilderFactory credentialBuilderFactory : credentialBuilderFactories) {
             assertThat(credentialBuilderFactory.getConfigProperties(), notNullValue());
         }
+    }
+
+    @Test
+    public void testLdpFactoriesDisabled() {
+        // LDP providers are intentionally disabled to keep scope limited to supported formats.
+        List<String> builderIds = session.getKeycloakSessionFactory()
+                .getProviderFactoriesStream(CredentialBuilder.class)
+                .map(f -> f.getId())
+                .toList();
+
+        assertThat(builderIds, not(hasItem("ldp_vc")));
+
+        List<String> signerIds = session.getKeycloakSessionFactory()
+                .getProviderFactoriesStream(CredentialSigner.class)
+                .map(f -> f.getId())
+                .toList();
+
+        assertThat(signerIds, not(hasItem("ldp_vc")));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/LDCredentialSignerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/LDCredentialSignerTest.java
@@ -42,11 +42,14 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.runonserver.RunOnServerException;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+// LDP_VC format is intentionally disabled to keep scope limited to supported formats.
+@Ignore("LDP_VC format is currently not supported and providers are disabled.")
 public class LDCredentialSignerTest extends OID4VCTest {
 
     @Before


### PR DESCRIPTION
This PR disables the `ldp_vc` format support in the OID4VCI implementation to resolve a `CredentialSignerException`. Following the strategy to focus on a stable initial version, we are prioritizing the fully supported `jwt_vc_json` and `dc+sd-jwt` formats.

## **Changes:**
* **Disabled Providers:** Commented out `LDCredentialBuilderFactory` and `LDCredentialSignerFactory` in `META-INF/services`.
* **Scope Logic:** Updated `VCFormat.java` to stop resolving `_ld` scope suffixes to `ldp_vc`.
* **Tests:** Added programmatic verification that `ldp_vc` providers are inactive and marked `LDCredentialSignerTest` as `@Ignore`.
* **Cleanup:** Removed temporary TODOs and issue links related to the LDP signing error.

## **Impact:**
Prevents runtime failures during credential issuance by ensuring the OID4VCI feature remains within its currently supported scope.

These changes were done following this comment: https://github.com/keycloak/keycloak/issues/44875#issuecomment-3756099107

closes https://github.com/keycloak/keycloak/issues/44875