### PR TITLE
Normalize hash algorithm names to lowercase

### DIFF
--- a/core/src/main/java/org/keycloak/sdjwt/IssuerSignedJWT.java
+++ b/core/src/main/java/org/keycloak/sdjwt/IssuerSignedJWT.java
@@ -170,7 +170,8 @@ public class IssuerSignedJWT extends JwsToken {
         }
         if (sdArray.size() > 0 || nestedDisclosures) {
             // add sd alg only if ay disclosure.
-            payload.put(CLAIM_NAME_SD_HASH_ALGORITHM, hashAlg);
+            // Normalize to lowercase to comply with IANA registered hash algorithm names
+            payload.put(CLAIM_NAME_SD_HASH_ALGORITHM, hashAlg.toLowerCase());
         }
 
         // then put all other claims in the paypload

--- a/core/src/main/java/org/keycloak/sdjwt/SdJwt.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwt.java
@@ -269,8 +269,9 @@ public class SdJwt {
             Optional.ofNullable(keyBindingJWT).ifPresent(keyBindJwt -> {
                 // get the hash-algorithm to use for keyBinding and set it if not present
                 String hashAlgorithm = getEffectiveHashAlgorithm(sdHashAlgorithm);
+                // Normalize to lowercase to comply with IANA registered hash algorithm names
                 issuerSignedJwt.getPayload().put(OID4VCConstants.CLAIM_NAME_SD_HASH_ALGORITHM,
-                                                 hashAlgorithm);
+                                                 hashAlgorithm.toLowerCase());
                 if (issuerSigningContext != null) {
                     issuerSignedJwt.sign(issuerSigningContext);
                 }

--- a/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
@@ -80,7 +80,9 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
 
   // Get available hash algorithms from server info
   const hashAlgorithms = serverInfo?.providers?.hash?.providers
-    ? Object.keys(serverInfo.providers.hash.providers).map(alg => alg.toLowerCase())
+    ? Object.keys(serverInfo.providers.hash.providers).map((alg) =>
+        alg.toLowerCase(),
+      )
     : [];
 
   // Get available asymmetric signature algorithms from server info

--- a/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
@@ -80,7 +80,7 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
 
   // Get available hash algorithms from server info
   const hashAlgorithms = serverInfo?.providers?.hash?.providers
-    ? Object.keys(serverInfo.providers.hash.providers)
+    ? Object.keys(serverInfo.providers.hash.providers).map(alg => alg.toLowerCase())
     : [];
 
   // Get available asymmetric signature algorithms from server info

--- a/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
@@ -424,7 +424,7 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
                   defaultValue:
                     clientScope?.attributes?.[
                       "vc.credential_build_config.hash_algorithm"
-                    ] ?? "SHA-256",
+                    ] ?? "sha-256",
                 }}
                 options={hashAlgorithms.map((alg) => ({
                   key: alg,

--- a/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
@@ -84,7 +84,7 @@ const TEST_VALUES = {
   ISSUER_DID: "did:key:test123",
   EXPIRY_SECONDS: "86400",
   SIGNING_ALG: "ES256",
-  HASH_ALGORITHM: "SHA-384",
+  HASH_ALGORITHM: "sha-384",
   TOKEN_JWS_TYPE: "dc+sd-jwt",
   VISIBLE_CLAIMS: "id,iat,nbf,exp,jti,given_name",
   DISPLAY:
@@ -465,7 +465,7 @@ test.describe("OID4VCI Client Scope Functionality", () => {
     await expect(page.getByTestId(OID4VCI_FIELDS.ISSUER_DID)).toHaveValue("");
     await expect(page.locator(OID4VCI_FIELDS.SIGNING_ALGORITHM)).toHaveText("");
     await expect(page.locator(OID4VCI_FIELDS.HASH_ALGORITHM)).toContainText(
-      "SHA-256",
+      "sha-256",
     );
     await expect(page.getByTestId(OID4VCI_FIELDS.DISPLAY)).toHaveValue("");
   });
@@ -614,7 +614,7 @@ test.describe("OID4VCI Client Scope Functionality", () => {
     );
   });
 
-  test("should default to SHA-256 when hash algorithm is not set", async ({
+  test("should default to sha-256 when hash algorithm is not set", async ({
     page,
   }) => {
     await using testBed = await createTestBed({
@@ -639,7 +639,7 @@ test.describe("OID4VCI Client Scope Functionality", () => {
     await navigateBackAndVerifyClientScope(page, testBed, testClientScopeName);
 
     await expect(page.locator(OID4VCI_FIELDS.HASH_ALGORITHM)).toContainText(
-      "SHA-256",
+      "sha-256",
     );
   });
 

--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -46,7 +46,7 @@ public class CredentialScopeModel implements ClientScopeModel {
     public static final String SD_JWT_VISIBLE_CLAIMS_DEFAULT = "id,iat,nbf,exp,jti";
     public static final int SD_JWT_DECOYS_DEFAULT = 10;
     public static final String FORMAT_DEFAULT = VCFormat.SD_JWT_VC;
-    public static final String HASH_ALGORITHM_DEFAULT = "SHA-256";
+    public static final String HASH_ALGORITHM_DEFAULT = "sha-256";
     public static final String TOKEN_TYPE_DEFAULT = "JWS";
     public static final int EXPIRY_IN_SECONDS_DEFAULT = 31536000; // 1 year
     public static final String CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT = "jwk";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderTest.java
@@ -124,8 +124,8 @@ public class SdJwtCredentialBuilderTest extends CredentialBuilderTest {
 
         ArrayNode sdArrayNode = (ArrayNode) jwt.getPayload().get(CLAIM_NAME_SD);
         if (sdArrayNode != null) {
-            assertEquals("The algorithm should be included",
-                    credentialBuildConfig.getHashAlgorithm(),
+            assertEquals("The algorithm should be included and lowercase",
+                    credentialBuildConfig.getHashAlgorithm().toLowerCase(),
                     jwt.getPayload().get(CLAIM_NAME_SD_HASH_ALGORITHM).asText());
         }
 


### PR DESCRIPTION
Ensure hash algorithm names are lowercase across multiple files to comply with IANA standards. Updated relevant code in IssuerSignedJWT, SdJwt, and CredentialScopeModel, and adjusted tests accordingly.

Closes https://github.com/adorsys/eudiw-app/issues/603