### PR TITLE
[OID4VCI] Migrate OID4VCKeyAttestationTest to the new testsuite

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -113,13 +113,13 @@ public abstract class OID4VCIssuerTestBase {
     CredentialScopeRepresentation sdJwtTypeCredentialScope;
 
     @InjectRealm(config = VCTestRealmConfig.class)
-    ManagedRealm testRealm;
+    protected ManagedRealm testRealm;
 
     @InjectClient(ref = "oid4vci-client", config = OID4VCIClient.class)
     ManagedClient managedClient;
 
     @InjectOAuthClient
-    OAuthClient oauth;
+    protected OAuthClient oauth;
 
     @InjectTimeOffSet
     TimeOffSet timeOffSet;
@@ -487,14 +487,14 @@ public abstract class OID4VCIssuerTestBase {
 
     // Config ----------------------------------------------------------------------------------------------------------
 
-    static class VCTestServerConfig implements KeycloakServerConfig {
+    public static class VCTestServerConfig implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
             return config.features(Profile.Feature.OID4VC_VCI);
         }
     }
 
-    static class VCTestRealmConfig implements RealmConfig {
+    public static class VCTestRealmConfig implements RealmConfig {
 
         public static final String TEST_REALM_NAME = "test";
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCKeyAttestationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCKeyAttestationTest.java
@@ -1,21 +1,4 @@
-/*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.keycloak.testsuite.oid4vc.issuance.signing;
+package org.keycloak.tests.oid4vc.issuance.signing;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -28,6 +11,8 @@ import java.util.Map;
 import javax.net.ssl.TrustManagerFactory;
 
 import org.keycloak.OID4VCConstants.KeyAttestationResistanceLevels;
+import org.keycloak.VCFormat;
+import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.crypto.ECDSASignatureSignerContext;
 import org.keycloak.crypto.KeyType;
@@ -36,6 +21,9 @@ import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationKeyResolver;
@@ -43,81 +31,113 @@ import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationProofValidato
 import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationProofValidatorFactory;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationValidatorUtil;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.JwtProofValidator;
-import org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidator;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.StaticAttestationKeyResolver;
+import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.KeyAttestationJwtBody;
 import org.keycloak.protocol.oid4vc.model.KeyAttestationsRequired;
+import org.keycloak.protocol.oid4vc.model.ProofTypesSupported;
 import org.keycloak.protocol.oid4vc.model.Proofs;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
+import org.keycloak.util.JsonSerialization;
 
 import org.jboss.logging.Logger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.keycloak.protocol.oid4vc.model.ProofType.JWT;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * @author Bertrand Ogen
- *
- * Test class for verifying Key Attestation
+ * Migrated OID4VCKeyAttestationTest to the new test framework.
  */
-
-public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+public class OID4VCKeyAttestationTest extends OID4VCIssuerTestBase {
 
     private static final Logger LOGGER = Logger.getLogger(OID4VCKeyAttestationTest.class);
+
+    private static final TimeProvider TIME_PROVIDER = new TimeProvider() {
+        private final int currentTimeInS = 1000;
+
+        @Override
+        public int currentTimeSeconds() {
+            return currentTimeInS;
+        }
+
+        @Override
+        public long currentTimeMillis() {
+            return currentTimeInS * 1000L;
+        }
+    };
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    private static void setupSessionContext(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName(OID4VCIssuerTestBase.VCTestRealmConfig.TEST_REALM_NAME);
+        session.getContext().setRealm(realm);
+    }
 
     @Test
     public void testValidAttestationProof() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
+        runOnServer.run(session -> {
+            setupSessionContext(session);
             runValidAttestationProofTest(session, cNonce);
         });
     }
 
     @Test
     public void testInvalidAttestationProof() {
-        testingClient.server(TEST_REALM_NAME).run(OID4VCKeyAttestationTest::runInvalidAttestationProofTest);
+        runOnServer.run(session -> {
+            setupSessionContext(session);
+            runInvalidAttestationProofTest(session);
+        });
     }
 
     @Test
     public void testValidJwtProofWithKeyAttestation() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
+        runOnServer.run(session -> {
+            setupSessionContext(session);
             runValidJwtProofWithKeyAttestationTest(session, cNonce);
         });
     }
 
-
     @Test
     public void testInvalidJwtProofWithKeyAttestation() {
-        testingClient.server(TEST_REALM_NAME).run(session -> {
-            try {
-                runInvalidJwtProofWithKeyAttestationTest(session);
-                fail("Expected VCIssuerException to be thrown");
-            } catch (VCIssuerException e) {
-                assertTrue(e.getMessage().contains("Could not validate JWT proof"));
-            }
+        runOnServer.run(session -> {
+            assertThrows(VCIssuerException.class, () -> runInvalidJwtProofWithKeyAttestationTest(session),
+                    "Expected VCIssuerException to be thrown");
         });
     }
 
     @Test
     public void testAttestationProofType() {
-        testingClient.server(TEST_REALM_NAME).run(session -> {
+        runOnServer.run(session -> {
+            setupSessionContext(session);
+
             AttestationProofValidatorFactory factory = new AttestationProofValidatorFactory();
-            ProofValidator validator = factory.create(session);
-            assertEquals("The proof type should be 'attestation'.",
-                    "attestation", validator.getProofType());
+            var validator = factory.create(session);
+            assertEquals("attestation", validator.getProofType(),
+                    "The proof type should be 'attestation'.");
         });
     }
 
     @Test
     public void testInvalidAttestationSignature() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
+        runOnServer.run(session -> {
+            setupSessionContext(session);
             try {
                 runInvalidAttestationSignatureTest(session, cNonce);
             } catch (Exception e) {
@@ -128,13 +148,17 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
 
     @Test
     public void testMissingRequiredAttestationClaims() {
-        testingClient.server(TEST_REALM_NAME).run(OID4VCKeyAttestationTest::runMissingRequiredAttestationClaimsTest);
+        runOnServer.run(session -> {
+            setupSessionContext(session);
+            runMissingRequiredAttestationClaimsTest(session);
+        });
     }
 
     @Test
     public void testAttestationWithMultipleAttestedKeys() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
+        runOnServer.run(session -> {
+            setupSessionContext(session);
             runAttestationWithMultipleAttestedKeys(session, cNonce);
         });
     }
@@ -142,39 +166,29 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
     @Test
     public void testAttestationWithX5cCertificateChain() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
-            try {
-                runAttestationWithX5cCertificateChain(session, cNonce);
-            } catch (VCIssuerException e) {
-                assertTrue("Expected error about invalid level but got: " + e.getMessage(),
-                        e.getMessage().contains("key_storage") ||
-                                e.getMessage().contains("INVALID_LEVEL"));
-            } catch (Exception e) {
-                fail("Unexpected exception: " + e.getMessage());
-            }
+        runOnServer.run(session -> {
+            setupSessionContext(session);
+            runAttestationWithX5cCertificateChain(session, cNonce);
         });
     }
 
     @Test
     public void testAttestationWithInvalidResistanceLevels() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
-            try {
-                runAttestationWithInvalidResistanceLevels(session, cNonce);
-            } catch (VCIssuerException e) {
-                assertTrue("Expected error about invalid level but got: " + e.getMessage(),
-                        e.getMessage().contains("key_storage") ||
-                                e.getMessage().contains("INVALID_LEVEL"));
-            } catch (Exception e) {
-                fail("Unexpected exception: " + e.getMessage());
-            }
+        runOnServer.run(session -> {
+            setupSessionContext(session);
+            VCIssuerException e = assertThrows(VCIssuerException.class,
+                    () -> runAttestationWithInvalidResistanceLevels(session, cNonce));
+            assertTrue(e.getMessage().contains("key_storage") && e.getMessage().contains("INVALID_LEVEL"),
+                    "Expected error about invalid level but got: " + e.getMessage());
         });
     }
 
     @Test
     public void testAttestationWithMissingAttestedKeys() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
+        runOnServer.run(session -> {
+            setupSessionContext(session);
             runAttestationWithMissingAttestedKeys(session, cNonce);
         });
     }
@@ -182,20 +196,129 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
     @Test
     public void testAttestationWithValidResistanceLevels() {
         String cNonce = getCNonce();
-        testingClient.server(TEST_REALM_NAME).run(session -> {
-            try {
-                runAttestationWithValidResistanceLevels(session, cNonce);
-            } catch (VCIssuerException e) {
-                assertTrue("Expected error about invalid level but got: " + e.getMessage(),
-                        e.getMessage().contains("key_storage") ||
-                                e.getMessage().contains("INVALID_LEVEL"));
-            } catch (Exception e) {
-                fail("Unexpected exception: " + e.getMessage());
-            }
+        runOnServer.run(session -> {
+            setupSessionContext(session);
+            runAttestationWithValidResistanceLevels(session, cNonce);
         });
     }
 
-    private static void runAttestationWithValidResistanceLevels(KeycloakSession session, String cNonce) {
+    private String getCNonce() {
+        return oauth.oid4vc().nonceRequest().send().getNonce();
+    }
+
+    private static KeyWrapper getECKey(String keyId) {
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+            kpg.initialize(new ECGenParameterSpec("secp256r1"));
+            KeyPair keyPair = kpg.generateKeyPair();
+            KeyWrapper kw = new KeyWrapper();
+            kw.setPrivateKey(keyPair.getPrivate());
+            kw.setPublicKey(keyPair.getPublic());
+            kw.setType(KeyType.EC);
+            kw.setAlgorithm("ES256");
+            if (keyId != null) {
+                kw.setKid(keyId);
+            }
+            return kw;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static VCIssuanceContext createVCIssuanceContext(KeycloakSession session) {
+        VCIssuanceContext context = new VCIssuanceContext();
+        KeyAttestationsRequired keyAttestationsRequired = new KeyAttestationsRequired();
+        keyAttestationsRequired.setKeyStorage(List.of(KeyAttestationResistanceLevels.HIGH,
+                KeyAttestationResistanceLevels.MODERATE));
+        SupportedCredentialConfiguration config = new SupportedCredentialConfiguration()
+                .setFormat(VCFormat.SD_JWT_VC)
+                .setVct("https://credentials.example.com/test-credential")
+                .setCryptographicBindingMethodsSupported(List.of("jwk"))
+                .setProofTypesSupported(ProofTypesSupported.parse(session, keyAttestationsRequired, List.of("ES256")));
+
+        context.setCredentialConfig(config)
+                .setCredentialRequest(new CredentialRequest());
+        return context;
+    }
+
+    private static String createValidAttestationJwt(KeycloakSession session,
+                                                    KeyWrapper attestationKey,
+                                                    JWK proofJwk,
+                                                    String cNonce) {
+        return createValidAttestationJwt(session, attestationKey, List.of(proofJwk), cNonce,
+                AttestationValidatorUtil.ATTESTATION_JWT_TYP);
+    }
+
+    private static String createValidAttestationJwt(KeycloakSession session,
+                                                    KeyWrapper attestationKey,
+                                                    List<JWK> proofJwks,
+                                                    String cNonce,
+                                                    String typ) {
+        try {
+            KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
+            payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
+            payload.setNonce(cNonce);
+            payload.setAttestedKeys(proofJwks);
+            payload.setKeyStorage(List.of(KeyAttestationResistanceLevels.HIGH));
+            payload.setUserAuthentication(List.of(KeyAttestationResistanceLevels.HIGH));
+
+            return new JWSBuilder()
+                    .type(typ)
+                    .kid(attestationKey.getKid())
+                    .jsonContent(payload)
+                    .sign(new ECDSASignatureSignerContext(attestationKey));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create attestation JWT", e);
+        }
+    }
+
+    private static String generateJwtProofWithKeyAttestation(KeycloakSession session,
+                                                             KeyWrapper proofKey,
+                                                             String attestationJwt,
+                                                             String cNonce) {
+        try {
+            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+            proofJwk.setKeyId(proofKey.getKid());
+            proofJwk.setAlgorithm(proofKey.getAlgorithm());
+
+            AccessToken token = new AccessToken();
+            String credentialIssuer = OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
+            token.addAudience(credentialIssuer);
+            token.setNonce(cNonce);
+            token.issuedNow();
+
+            Map<String, Object> header = new HashMap<>();
+            header.put("alg", proofKey.getAlgorithm());
+            header.put("typ", JwtProofValidator.PROOF_JWT_TYP);
+            header.put("jwk", proofJwk);
+            header.put("key_attestation", attestationJwt);
+
+            return new JWSBuilder() {
+                @Override
+                protected String encodeHeader(String sigAlgName) {
+                    try {
+                        return Base64Url.encode(JsonSerialization.writeValueAsBytes(header));
+                    } catch (Exception e) {
+                        throw new RuntimeException("Failed to encode header", e);
+                    }
+                }
+            }.jsonContent(token).sign(new ECDSASignatureSignerContext(proofKey));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate JWT proof with key attestation", e);
+        }
+    }
+
+    private static KeyAttestationJwtBody createAttestationPayload(JWK proofJwk, String cNonce) {
+        KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
+        payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
+        payload.setNonce(cNonce);
+        payload.setAttestedKeys(List.of(proofJwk));
+        payload.setKeyStorage(List.of(KeyAttestationResistanceLevels.HIGH));
+        payload.setUserAuthentication(List.of(KeyAttestationResistanceLevels.HIGH));
+        return payload;
+    }
+
+    private static void runAttestationWithValidResistanceLevels(KeycloakSession session, String cNonce) throws VCIssuerException {
         try {
             KeyWrapper attestationKey = getECKey("attestationKey");
             KeyWrapper proofKey = getECKey("proofKey");
@@ -204,7 +327,6 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
             proofJwk.setKeyId(proofKey.getKid());
             proofJwk.setAlgorithm(proofKey.getAlgorithm());
 
-            // Create a complete payload
             KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
             payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
             payload.setNonce(cNonce);
@@ -225,7 +347,6 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
                     .sign(new ECDSASignatureSignerContext(attestationKey));
 
             VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
-            // Set attestation requirements
             KeyAttestationsRequired attestationRequirements = new KeyAttestationsRequired();
             attestationRequirements.setKeyStorage(List.of(
                     KeyAttestationResistanceLevels.HIGH,
@@ -252,11 +373,10 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
             AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
             List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
 
-            assertNotNull("Attested keys should not be null", attestedKeys);
-            assertEquals("Should contain exactly one attested key", 1, attestedKeys.size());
-            assertEquals("Attested key ID should match proof key ID",
-                    proofKey.getKid(),
-                    attestedKeys.get(0).getKeyId());
+            assertNotNull(attestedKeys, "Attested keys should not be null");
+            assertEquals(1, attestedKeys.size(), "Should contain exactly one attested key");
+            assertEquals(proofKey.getKid(), attestedKeys.get(0).getKeyId(),
+                    "Attested key ID should match proof key ID");
         } catch (Exception e) {
             LOGGER.error("Validation failed with valid resistance levels", e);
             fail("Test should not throw exception: " + e.getMessage());
@@ -264,45 +384,37 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
     }
 
     private static void runValidAttestationProofTest(KeycloakSession session, String cNonce) {
-        try {
-            KeyWrapper attestationKey = getECKey("attestationKey");
-            KeyWrapper proofKey = getECKey("proofKey");
+        KeyWrapper attestationKey = getECKey("attestationKey");
+        KeyWrapper proofKey = getECKey("proofKey");
 
-            attestationKey.setKid("attestationKey");
-            attestationKey.setAlgorithm("ES256");
-            proofKey.setKid("proofKey");
-            proofKey.setAlgorithm("ES256");
+        attestationKey.setKid("attestationKey");
+        attestationKey.setAlgorithm("ES256");
+        proofKey.setKid("proofKey");
+        proofKey.setAlgorithm("ES256");
 
-            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
-            proofJwk.setKeyId(proofKey.getKid());
-            proofJwk.setAlgorithm(proofKey.getAlgorithm());
+        JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+        proofJwk.setKeyId(proofKey.getKid());
+        proofJwk.setAlgorithm(proofKey.getAlgorithm());
 
+        String attestationJwt = createValidAttestationJwt(session, attestationKey, proofJwk, cNonce);
+        String jwtProof = generateJwtProofWithKeyAttestation(session, proofKey, attestationJwt, cNonce);
+        VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+        vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(jwtProof)));
 
-            String attestationJwt = createValidAttestationJwt(session, attestationKey, proofJwk, cNonce);
-            String jwtProof = generateJwtProofWithKeyAttestation(session, proofKey, attestationJwt, cNonce);
-            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
-            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(jwtProof)));
+        JWK attestationJwk = JWKBuilder.create().ec(attestationKey.getPublicKey());
+        attestationJwk.setKeyId(attestationKey.getKid());
 
-            JWK attestationJwk = JWKBuilder.create().ec(attestationKey.getPublicKey());
-            attestationJwk.setKeyId(attestationKey.getKid());
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                Map.of(attestationKey.getKid(), attestationJwk)
+        );
 
-            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
-                    Map.of(attestationKey.getKid(), attestationJwk)
-            );
+        JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
+        List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
 
-            JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
-            List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
-
-            assertNotNull("Attested keys should not be null", attestedKeys);
-            assertEquals("Should contain exactly one attested key", 1, attestedKeys.size());
-            assertEquals("Attested key ID should match proof key ID",
-                    proofKey.getKid(),
-                    attestedKeys.get(0).getKeyId());
-
-        } catch (Exception e) {
-            LOGGER.error("Validation failed", e);
-            fail("Test should not throw exception: " + e.getMessage());
-        }
+        assertNotNull(attestedKeys, "Attested keys should not be null");
+        assertEquals(1, attestedKeys.size(), "Should contain exactly one attested key");
+        assertEquals(proofKey.getKid(), attestedKeys.get(0).getKeyId(),
+                "Attested key ID should match proof key ID");
     }
 
     private static void runInvalidAttestationProofTest(KeycloakSession session) {
@@ -312,57 +424,50 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
         VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
         vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(invalidAttestationJwt)));
 
-        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
         AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
 
-        try {
-            validator.validateProof(vcIssuanceContext);
-            fail("Expected VCIssuerException to be thrown");
-        } catch (VCIssuerException e) {
-            // Expected exception
-        }
+        assertThrows(VCIssuerException.class, () -> validator.validateProof(vcIssuanceContext),
+                "Expected VCIssuerException to be thrown");
     }
 
     private static void runValidJwtProofWithKeyAttestationTest(KeycloakSession session, String cNonce) {
-        try {
-            KeyWrapper attestationKey = getECKey("attestationKey");
-            KeyWrapper proofKey = getECKey("proofKey");
-            JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
+        KeyWrapper attestationKey = getECKey("attestationKey");
+        KeyWrapper proofKey = getECKey("proofKey");
+        JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
 
-            String attestationJwt = createValidAttestationJwt(session, attestationKey, proofJwk, cNonce);
-            String jwtProof = generateJwtProofWithKeyAttestation(session, proofKey, attestationJwt, cNonce);
+        String attestationJwt = createValidAttestationJwt(session, attestationKey, proofJwk, cNonce);
+        String jwtProof = generateJwtProofWithKeyAttestation(session, proofKey, attestationJwt, cNonce);
 
-            VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
-            vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(jwtProof)));
+        VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
+        vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(jwtProof)));
 
-            AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
-                    Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey()))
-            );
-            JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey()))
+        );
+        JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
 
-            List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
-            assertNotNull(attestedKeys);
-            assertFalse(attestedKeys.isEmpty());
-        } catch (Exception e) {
-            LOGGER.error("Validation failed unexpectedly", e);
-            fail("Unexpected exception in valid JWT proof test: " + e.getMessage());
-        }
+        List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
+        assertNotNull(attestedKeys);
+        assertFalse(attestedKeys.isEmpty());
     }
 
-    private static void runInvalidJwtProofWithKeyAttestationTest(KeycloakSession session) {
+    private static void runInvalidJwtProofWithKeyAttestationTest(KeycloakSession session) throws VCIssuerException {
         KeyWrapper attestationKey = getECKey("attestationKey");
         String invalidJwtProof = "invalid.jwt.token";
 
         VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
         vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setJwt(List.of(invalidJwtProof)));
 
-        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
         JwtProofValidator validator = new JwtProofValidator(session, keyResolver);
 
         validator.validateProof(vcIssuanceContext);
     }
 
-    private static void runInvalidAttestationSignatureTest(KeycloakSession session, String cNonce) {
+    private static void runInvalidAttestationSignatureTest(KeycloakSession session, String cNonce) throws Exception {
         KeyWrapper attestationKey = getECKey("attestationKey");
         KeyWrapper proofKey = getECKey("proofKey");
         JWK proofJwk = JWKBuilder.create().ec(proofKey.getPublicKey());
@@ -377,15 +482,12 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
         VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
         vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(invalidAttestationJwt)));
 
-        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
         AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
 
-        try {
-            validator.validateProof(vcIssuanceContext);
-            fail("Expected VCIssuerException to be thrown");
-        } catch (VCIssuerException e) {
-            assertTrue("Expected VCIssuerException to be thrown", true);
-        }
+        assertThrows(VCIssuerException.class, () -> validator.validateProof(vcIssuanceContext),
+                "Expected VCIssuerException to be thrown");
     }
 
     private static void runMissingRequiredAttestationClaimsTest(KeycloakSession session) {
@@ -403,15 +505,12 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
         VCIssuanceContext vcIssuanceContext = createVCIssuanceContext(session);
         vcIssuanceContext.getCredentialRequest().setProofs(new Proofs().setAttestation(List.of(invalidAttestationJwt)));
 
-        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
+        AttestationKeyResolver keyResolver = new StaticAttestationKeyResolver(
+                Map.of(attestationKey.getKid(), JWKBuilder.create().ec(attestationKey.getPublicKey())));
         AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
 
-        try {
-            validator.validateProof(vcIssuanceContext);
-            fail("Expected VCIssuerException to be thrown");
-        } catch (VCIssuerException e) {
-            assertTrue("Expected VCIssuerException to be thrown", true);
-        }
+        assertThrows(VCIssuerException.class, () -> validator.validateProof(vcIssuanceContext),
+                "Expected VCIssuerException to be thrown");
     }
 
     private static void runAttestationWithMultipleAttestedKeys(KeycloakSession session, String cNonce) {
@@ -428,7 +527,6 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
             proofJwk2.setKeyId(proofKey2.getKid());
             proofJwk2.setAlgorithm(proofKey2.getAlgorithm());
 
-            // Create a proper payload with attested keys
             KeyAttestationJwtBody payload = new KeyAttestationJwtBody();
             payload.setIat((long) TIME_PROVIDER.currentTimeSeconds());
             payload.setNonce(cNonce);
@@ -468,7 +566,6 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
             KeyPair keyPair = keyGen.generateKeyPair();
 
             X509Certificate cert = CertificateUtils.generateV1SelfSignedCertificate(keyPair, "Test Certificate");
-            Logger.getLogger(OID4VCKeyAttestationTest.class).info("Generated certificate: " + cert.toString());
 
             KeyWrapper signerKey = new KeyWrapper();
             signerKey.setPrivateKey(keyPair.getPrivate());
@@ -514,16 +611,16 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
             AttestationProofValidator validator = new AttestationProofValidator(session, keyResolver);
             List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
 
-            assertNotNull("Attested keys should not be null", attestedKeys);
-            assertEquals("Should contain exactly one attested key", 1, attestedKeys.size());
-            assertEquals("Attested key ID should match proof key ID", proofKey.getKid(), attestedKeys.get(0).getKeyId());
+            assertNotNull(attestedKeys, "Attested keys should not be null");
+            assertEquals(1, attestedKeys.size(), "Should contain exactly one attested key");
+            assertEquals(proofKey.getKid(), attestedKeys.get(0).getKeyId(),
+                    "Attested key ID should match proof key ID");
         } catch (Exception e) {
-            LOGGER.error("Certificate chain validation failed", e);
-            fail("Test should not throw exception: " + e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 
-    private static void runAttestationWithInvalidResistanceLevels(KeycloakSession session, String cNonce) {
+    private static void runAttestationWithInvalidResistanceLevels(KeycloakSession session, String cNonce) throws VCIssuerException {
         try {
             KeyWrapper attestationKey = getECKey("attestationKey");
             KeyWrapper proofKey = getECKey("proofKey");
@@ -554,8 +651,7 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
             new AttestationProofValidator(session, keyResolver).validateProof(vcIssuanceContext);
             fail("Expected VCIssuerException for invalid resistance level");
         } catch (VCIssuerException e) {
-            assertTrue("Expected error about invalid level but got: " + e.getMessage(),
-                    e.getMessage().contains("key_storage") && e.getMessage().contains("INVALID_LEVEL"));
+            throw e;
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }
@@ -587,9 +683,8 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerEndpointTest {
             validator.validateProof(context);
             fail("Expected VCIssuerException for missing attested_keys");
         } catch (VCIssuerException e) {
-            assertEquals("Expected error about missing keys but got: " + e.getMessage(),
-                         "key_storage is required but was missing.",
-                         e.getMessage());
+            assertEquals("key_storage is required but was missing.", e.getMessage(),
+                    "Expected error about missing keys but got: " + e.getMessage());
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }


### PR DESCRIPTION
### Summary

This PR migrates `OID4VCKeyAttestationTest` from the deprecated Arquillian testsuite to the new JUnit 5 `tests/base` framework.

The test was updated to use the new test infrastructure, including `RunOnServerClient` for server-side execution and proper realm context initialization. Required helper logic (key generation, attestation JWT creation, proof generation, and `VCIssuanceContext` setup) was inlined to make the test self-contained.

It also reuses the existing OID4VC nonce endpoint and aligns the generated proof JWT with server-side validation requirements (correct audience and `c_nonce` handling).

closes https://github.com/keycloak/keycloak/issues/46599