### PR TITLE
CnonceHandler is always present. Small improve checking for allowed a…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
@@ -44,6 +44,7 @@ import java.util.Set;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
@@ -135,7 +136,7 @@ public class AttestationValidatorUtil {
         }
 
         JWSHeader header = jwsInput.getHeader();
-        validateJwsHeader(header, vcIssuanceContext, proofTypeKeyForSigningAlgPolicy);
+        validateJwsHeader(keycloakSession, header, vcIssuanceContext, proofTypeKeyForSigningAlgPolicy);
 
         // Verify the signature
         Map<String, Object> rawHeader = JsonSerialization.mapper.convertValue(
@@ -196,19 +197,12 @@ public class AttestationValidatorUtil {
         KeycloakContext keycloakContext = keycloakSession.getContext();
         CNonceHandler cNonceHandler = keycloakSession.getProvider(CNonceHandler.class);
 
-        // If CNonceHandler is available, nonce endpoint exists and nonce is required
-        boolean nonceRequired = cNonceHandler != null;
-
-        if (nonceRequired && attestationBody.getNonce() == null) {
+        if (attestationBody.getNonce() == null) {
             throw new VCIssuerException(ErrorType.INVALID_PROOF, "Missing 'nonce' in attestation");
         }
 
         // Validate nonce if present. If provided, it must correspond to a nonce value provided by Keycloak.
         if (attestationBody.getNonce() != null) {
-            if (cNonceHandler == null) {
-                throw new VCIssuerException(ErrorType.INVALID_PROOF, "No CNonceHandler available");
-            }
-
             try {
                 cNonceHandler.verifyCNonce(
                         attestationBody.getNonce(),
@@ -321,18 +315,15 @@ public class AttestationValidatorUtil {
                 .filter(algs -> !algs.isEmpty());
     }
 
-    private static void validateJwsHeader(JWSHeader header, VCIssuanceContext vcIssuanceContext,
+    private static void validateJwsHeader(KeycloakSession session, JWSHeader header, VCIssuanceContext vcIssuanceContext,
                                           String proofTypeKeyForSigningAlgPolicy) {
         String alg = Optional.ofNullable(header.getAlgorithm())
                 .map(Algorithm::name)
                 .orElseThrow(() -> new VCIssuerException(ErrorType.INVALID_PROOF, "Missing algorithm in JWS header"));
 
-        if ("none".equalsIgnoreCase(alg)) {
-            throw new VCIssuerException(ErrorType.INVALID_PROOF, "'none' algorithm is not allowed");
-        }
-
-        if (alg.startsWith("HS")) {
-            throw new VCIssuerException(ErrorType.INVALID_PROOF, "Symmetric algorithms are not allowed for key attestation");
+        List<String> supportedAsymmetricAlgs = CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session);
+        if (!supportedAsymmetricAlgs.contains(alg)) {
+            throw new VCIssuerException(ErrorType.INVALID_PROOF, "Unsupported algorithm for key attestation. Only asymmetric algorithms are allowed");
         }
 
         Optional<List<String>> metadataAlgs = resolveProofSigningAlgorithms(vcIssuanceContext, proofTypeKeyForSigningAlgPolicy);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKParser;
@@ -67,7 +68,7 @@ public class JwtProofValidator extends AbstractProofValidator {
     public static final String PROOF_JWT_TYP = "openid4vci-proof+jwt";
     private static final String CRYPTOGRAPHIC_BINDING_METHOD_JWK = "jwk";
     private static final String KEY_ATTESTATION_CLAIM = "key_attestation";
-    // JOSE private JWK parameters across RSA/EC/OKP/oct key types.
+    // JOSE private JWK parameters across RSA/EC/OKP/oct key types. TODO: This is not very reliable and should be either removed or improved to cover the cases when other algorithms are introduced in the future
     private static final Set<String> JWK_PRIVATE_KEY_CLAIMS = Set.of("d", "p", "q", "dp", "dq", "qi", "oth", "k");
     private static final int PROOF_MAX_AGE_SECONDS = 30;
     private static final int PROOF_FUTURE_SKEW_SECONDS = 10;
@@ -272,7 +273,7 @@ public class JwtProofValidator extends AbstractProofValidator {
         String alg = Optional.ofNullable(jwsHeader.getAlgorithm())
                 .map(algorithm -> algorithm.name())
                 .orElseThrow(() -> new VCIssuerException(ErrorType.INVALID_PROOF, "Missing jwsHeader claim alg"));
-        if ("none".equalsIgnoreCase(alg) || alg.startsWith("HS")) {
+        if (!CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(keycloakSession).contains(alg)) {
             throw new VCIssuerException(ErrorType.INVALID_PROOF, "Proof signature algorithm not supported: " + alg);
         }
 


### PR DESCRIPTION
…lgorithms

Very small cleanup during review of the PR https://github.com/keycloak/keycloak/pull/47995 :

- `cNonceHandler` provider is always present now within Keycloak server. No need for handling the case when it is not present as we're not going to support that

- Checking of algorithm like `alg.startsWith("HS")` is not very reliable and flexible as if some custom symmetric algorithm (not starting with `HS`) is deployed, this may not work
