### PR TITLE
Store OID4VCI credential offer once with alias lookups 

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferLookupKey.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferLookupKey.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
+
+/**
+ * Embeds the single-use cache key ({@code credentialsOfferId}) into externally visible lookup values
+ * (nonce, credential identifiers) so only one entry is stored in {@code singleUseObjects}.
+ */
+public final class CredentialOfferLookupKey {
+
+    private static final char SEPARATOR = ':';
+
+    private CredentialOfferLookupKey() {
+    }
+
+    public static String embed(String publicPart, String offerId) {
+        return publicPart + SEPARATOR + offerId;
+    }
+
+    public static String extractOfferId(String lookupValue) {
+        if (lookupValue == null) {
+            return null;
+        }
+        int separatorIndex = lookupValue.lastIndexOf(SEPARATOR);
+        if (separatorIndex < 0 || separatorIndex == lookupValue.length() - 1) {
+            return null;
+        }
+        return lookupValue.substring(separatorIndex + 1);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
@@ -67,7 +67,8 @@ public class CredentialOfferState {
         this.targetClientId = clientId;
         this.targetUserId = userId;
         this.expiresAt = expiresAt;
-        this.nonce = Base64Url.encode(RandomSecret.createRandomSecret(64));
+        String nonceSecret = Base64Url.encode(RandomSecret.createRandomSecret(64));
+        this.nonce = CredentialOfferLookupKey.embed(nonceSecret, credentialsOfferId);
         if (authDetailsProvider != null) {
             this.authDetails = authDetailsProvider.apply(credentialsOfferId);
         }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
@@ -17,6 +17,7 @@
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.keycloak.common.util.Time;
@@ -74,13 +75,11 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
             return;
         }
         
+        SingleUseObjectProvider singleUseObjects = session.singleUseObjects();
+        String offerId = entry.getCredentialsOfferId();
         String entryJson = JsonSerialization.valueAsString(entry);
 
-        // Store with key=offerId
-        session.singleUseObjects().put(entry.getCredentialsOfferId(), lifespanSeconds, Map.of(ENTRY_KEY, entryJson));
-
-        // Store with key=nonce
-        session.singleUseObjects().put(entry.getNonce(), lifespanSeconds, Map.of(ENTRY_KEY, entryJson));
+        singleUseObjects.put(offerId, lifespanSeconds, Map.of(ENTRY_KEY, entryJson));
     }
 
     @Override
@@ -93,16 +92,19 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
 
     @Override
     public CredentialOfferState getOfferStateByNonce(String nonce) {
-        return Optional.ofNullable(session.singleUseObjects().get(nonce))
-                .map(o -> o.get(ENTRY_KEY))
-                .map(o -> JsonSerialization.valueFromString(o, CredentialOfferState.class))
-                .orElse(null);
+        String offerId = CredentialOfferLookupKey.extractOfferId(nonce);
+        if (offerId == null) {
+            return null;
+        }
+        CredentialOfferState offerState = getOfferStateById(offerId);
+        if (offerState == null || !Objects.equals(nonce, offerState.getNonce())) {
+            return null;
+        }
+        return offerState;
     }
 
     @Override
     public void removeOfferState(CredentialOfferState offerState) {
-        SingleUseObjectProvider singleUseObjects = session.singleUseObjects();
-        singleUseObjects.remove(offerState.getCredentialsOfferId());
-        singleUseObjects.remove(offerState.getNonce());
+        session.singleUseObjects().remove(offerState.getCredentialsOfferId());
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCJWTIssuerEndpointPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCJWTIssuerEndpointPreAuthTest.java
@@ -171,7 +171,7 @@ public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest
         String nonce = credentialOfferURI.getNonce();
         assertNotNull(nonce, "Nonce should not be null");
 
-        // 2. Fetch the Offer JSON (this removes the nonce entry for replay protection)
+        // 2. Fetch the Offer JSON (offer state remains in storage until expiry or credential issuance)
         CredentialsOffer credentialsOffer = oauth.oid4vc()
                 .credentialOfferRequest(nonce)
                 .bearerToken(token)
@@ -201,8 +201,39 @@ public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest
                 .preAuthorizedCodeGrantRequest(preAuthorizedCode)
                 .send();
 
-        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode(), "Token request should succeed even after nonce is removed for replay protection");
+        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode(), "Token request should succeed after credential offer was fetched");
         assertNotNull(accessTokenResponse.getAccessToken(), "Access token should be present");
         assertFalse(accessTokenResponse.getAccessToken().isEmpty(), "Access token should not be empty");
+    }
+
+    @Test
+    public void testCredentialOfferRequestWithTamperedNonceSecretIsRejected() {
+        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
+        final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
+                .get(CredentialScopeModel.VC_CONFIGURATION_ID);
+
+        CredentialOfferURI credentialOfferURI = oauth.oid4vc()
+                .credentialOfferUriRequest(credentialConfigurationId)
+                .preAuthorized(true)
+                .targetUser("john")
+                .bearerToken(token)
+                .send()
+                .getCredentialOfferURI();
+
+        String nonce = credentialOfferURI.getNonce();
+        assertNotNull(nonce);
+
+        int separatorIndex = nonce.lastIndexOf(':');
+        assertTrue(separatorIndex > 0, "Nonce must embed the offer id");
+        String tamperedNonce = "tampered-secret" + nonce.substring(separatorIndex);
+
+        CredentialOfferResponse response = oauth.oid4vc()
+                .credentialOfferRequest(tamperedNonce)
+                .bearerToken(token)
+                .send();
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode(),
+                "Credential offer request with wrong nonce secret must be rejected");
+        assertEquals("Credential offer not found or already consumed", response.getErrorDescription());
     }
 }


### PR DESCRIPTION
## Summary
- Store a single `CredentialOfferState` entry in `singleUseObjects` under `credentialsOfferId`.
- Embed that id in the nonce and credential identifiers (`value:offerId`); `getOfferStateByNonce` parses and resolves via `getOfferStateById`.
- Pre-authorized flow unchanged: resolve via `credentials_offer_id` in the JWT context.

## Testing
./mvnw clean install -DskipTests && ./mvnw clean install -DskipTests -f distribution/pom.xml
./mvnw test -pl tests/base -Dtest="org.keycloak.tests.oid4vc.

Closes #45931
