### PR TITLE
[OID4VCI]  Fix  c_nonce replay protection

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -28,10 +28,12 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.BadRequestException;
@@ -65,6 +67,8 @@ import org.keycloak.jose.jwe.JWEException;
 import org.keycloak.jose.jwe.JWEHeader;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKParser;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
@@ -102,6 +106,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.ErrorResponse;
 import org.keycloak.protocol.oid4vc.model.ErrorType;
 import org.keycloak.protocol.oid4vc.model.JwtProof;
+import org.keycloak.protocol.oid4vc.model.KeyAttestationJwtBody;
 import org.keycloak.protocol.oid4vc.model.NonceResponse;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.OfferResponseType;
@@ -1023,6 +1028,8 @@ public class OID4VCIssuerEndpoint {
             credentialRequest.setProofs(originalProofs);
         }
 
+        consumeProofCNonce(credentialRequest);
+
         // Encrypt all responses if encryption parameters are provided, except for error credential responses
         Response response;
         if (encryptionParams != null && !responseVO.getCredentials().isEmpty()) {
@@ -1333,6 +1340,57 @@ public class OID4VCIssuerEndpoint {
 
         // Validation already happened in normalizeProofFields, so we can safely extract proofs
         return proofs.getAllProofs();
+    }
+
+    private void consumeProofCNonce(CredentialRequest credentialRequest) {
+        Proofs proofs = credentialRequest.getProofs();
+        if (proofs == null) {
+            return;
+        }
+
+        Set<String> cNonces = extractProofCNonce(proofs);
+        if (cNonces.isEmpty()) {
+            return;
+        }
+
+        CNonceHandler cNonceHandler = session.getProvider(CNonceHandler.class);
+        if (cNonceHandler == null) {
+            throw new ErrorResponseException(INVALID_PROOF.getValue(), "CNonce handler not configured", Response.Status.BAD_REQUEST);
+        }
+
+        for (String cNonce : cNonces) {
+            try {
+                cNonceHandler.consumeCNonce(cNonce);
+            } catch (VerificationException e) {
+                throw new ErrorResponseException(INVALID_NONCE.getValue(), e.getMessage(), Response.Status.BAD_REQUEST);
+            }
+        }
+    }
+
+    private Set<String> extractProofCNonce(Proofs proofs) {
+        Set<String> cNonces = new LinkedHashSet<>();
+        try {
+            if (proofs.getJwt() != null) {
+                for (String jwtProof : proofs.getJwt()) {
+                    AccessToken proofPayload = new JWSInput(jwtProof).readJsonContent(AccessToken.class);
+                    if (!Strings.isEmpty(proofPayload.getNonce())) {
+                        cNonces.add(proofPayload.getNonce());
+                    }
+                }
+            }
+            if (proofs.getAttestation() != null) {
+                for (String attestationProof : proofs.getAttestation()) {
+                    KeyAttestationJwtBody attestationBody = new JWSInput(attestationProof)
+                            .readJsonContent(KeyAttestationJwtBody.class);
+                    if (!Strings.isEmpty(attestationBody.getNonce())) {
+                        cNonces.add(attestationBody.getNonce());
+                    }
+                }
+            }
+        } catch (JWSInputException e) {
+            throw new ErrorResponseException(INVALID_PROOF.getValue(), "Could not parse provided proof", Response.Status.BAD_REQUEST);
+        }
+        return cNonces;
     }
 
     private void enforceProofContractForCredential(SupportedCredentialConfiguration credentialConfiguration, Proofs proofs) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidator.java
@@ -20,13 +20,8 @@ package org.keycloak.protocol.oid4vc.issuance.keybinding;
 import java.util.List;
 import java.util.Optional;
 
-import org.keycloak.common.util.Time;
-import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.jose.jwk.JWK;
-import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
 import org.keycloak.protocol.oid4vc.model.ErrorType;
@@ -34,10 +29,6 @@ import org.keycloak.protocol.oid4vc.model.KeyAttestationJwtBody;
 import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
-
-import org.apache.commons.codec.binary.Hex;
-
-import static org.keycloak.protocol.oid4vc.model.ErrorType.INVALID_NONCE;
 
 /**
  * Validates attestation proofs as per OID4VCI specification.
@@ -75,19 +66,6 @@ public class AttestationProofValidator extends AbstractProofValidator {
 
             if (attestationBody.getAttestedKeys() == null || attestationBody.getAttestedKeys().isEmpty()) {
                 throw new VCIssuerException(ErrorType.INVALID_PROOF, "No valid attested keys found in attestation proof");
-            }
-
-            // Nonce replay protection
-            //
-            String nonce = attestationBody.getNonce();
-            if (nonce != null) {
-                RealmModel realmModel = keycloakSession.getContext().getRealm();
-                SingleUseObjectProvider singleUseCache = keycloakSession.singleUseObjects();
-                String hashString = Hex.encodeHexString(HashUtils.hash("SHA1", nonce.getBytes()));
-                Long nonceLifetimeSeconds = realmModel.getAttribute(OID4VCIConstants.C_NONCE_LIFETIME_IN_SECONDS, 60L);
-                if (!singleUseCache.putIfAbsent(hashString, Time.currentTime() + 10 * nonceLifetimeSeconds)) {
-                    throw new VCIssuerException(INVALID_NONCE, "Nonce in proof has already been used");
-                }
             }
 
             return attestationBody.getAttestedKeys();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/CNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/CNonceHandler.java
@@ -52,6 +52,15 @@ public interface CNonceHandler extends Provider {
      */
     public void verifyCNonce(String cNonce, List<String> audiences, @Nullable Map<String, Object> additionalDetails) throws VerificationException;
 
+    /**
+     * Marks a verified cNonce value as consumed.
+     *
+     * @param cNonce the cNonce to consume
+     */
+    public default void consumeCNonce(String cNonce) throws VerificationException {
+        throw new VerificationException("c_nonce consumption is not supported");
+    }
+
     @Override
     default void close() {
         // do nothing

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
@@ -18,6 +18,7 @@
 
 package org.keycloak.protocol.oid4vc.issuance.keybinding;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -41,9 +42,11 @@ import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.model.JwtCNonce;
 import org.keycloak.representations.JsonWebToken;
@@ -61,6 +64,8 @@ public class JwtCNonceHandler implements CNonceHandler {
     public static final int NONCE_DEFAULT_LENGTH = 50;
 
     public static final int NONCE_LENGTH_RANDOM_OFFSET = 15;
+
+    private static final long CONSUMED_NONCE_CACHE_CLOCK_SKEW_SECONDS = 60;
 
     private static final Logger logger = Logger.getLogger(JwtCNonceHandler.class);
 
@@ -168,6 +173,38 @@ public class JwtCNonceHandler implements CNonceHandler {
                                                                     .verifier(signingKey);
         verifier.verifierContext(signatureVerifier);
         verifier.verify(); // throws a VerificationException on failure
+    }
+
+    @Override
+    public void consumeCNonce(String cNonce) throws VerificationException {
+        JsonWebToken cNonceToken = TokenVerifier.create(cNonce, JsonWebToken.class).getToken();
+        Long exp = cNonceToken.getExp();
+        if (exp == null) {
+            throw new VerificationException("c_nonce has no expiration time");
+        }
+
+        long now = Time.currentTime();
+        long expiresIn = exp - now + CONSUMED_NONCE_CACHE_CLOCK_SKEW_SECONDS;
+        if (expiresIn <= 0) {
+            String message = String.format(
+                    "c_nonce not valid: %s(exp) < %s(now)",
+                    exp,
+                    now);
+            throw new VerificationException(message);
+        }
+
+        SingleUseObjectProvider singleUseStore = keycloakSession.singleUseObjects();
+        String key = getCNonceSingleUseObjectKey(cNonce);
+        boolean firstInsertion = singleUseStore.putIfAbsent(key, expiresIn);
+        if (!firstInsertion) {
+            throw new VerificationException("c_nonce has already been used");
+        }
+    }
+
+    private static String getCNonceSingleUseObjectKey(String cNonce) {
+        String hash = HashUtils.sha256UrlEncodedHash(cNonce.trim(), StandardCharsets.UTF_8);
+        String fqcn = JwtCNonceHandler.class.getName().toLowerCase();
+        return fqcn + "." + hash;
     }
 
     protected boolean checkAttributeEquality(String key, Object object, Object actualValue) throws VerificationException {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/NonceEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/NonceEndpointTest.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSHeader;
@@ -77,6 +78,31 @@ public class NonceEndpointTest extends OID4VCIssuerTestBase {
                     List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
                     Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
                             OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext)));
+        });
+    }
+
+    @Test
+    public void testCNonceCanOnlyBeVerifiedOnce() throws Exception {
+        Oid4vcNonceResponse response = oauth.oid4vc().nonceRequest().send();
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode(),
+                "Nonce endpoint should return 200 OK");
+
+        String cNonce = response.getNonce();
+        Assertions.assertNotNull(cNonce);
+
+        runOnServer.run(session -> {
+            CNonceHandler cNonceHandler = session.getProvider(CNonceHandler.class);
+            var keycloakContext = session.getContext();
+
+            cNonceHandler.verifyCNonce(cNonce,
+                    List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
+                    Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
+                            OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext)));
+            cNonceHandler.consumeCNonce(cNonce);
+
+            VerificationException exception = Assertions.assertThrows(VerificationException.class,
+                    () -> cNonceHandler.consumeCNonce(cNonce));
+            Assertions.assertEquals("c_nonce has already been used", exception.getMessage());
         });
     }
 


### PR DESCRIPTION
Fixes OID4VCI `c_nonce` replay protection by marking verified proof nonces as consumed after successful credential request processing.

The nonce is stored in `SingleUseObjectProvider` using a hashed key, with the cache lifetime calculated from the remaining nonce validity plus clock skew. This prevents a captured proof JWT from being replayed within the nonce validity window.

## Details

- Add `CNonceHandler.consumeCNonce()` for explicit nonce consumption.
- Implement single-use storage in `JwtCNonceHandler` with `putIfAbsent()`.
- Calculate cache TTL as `exp - now + clockSkew`.
- Consume each distinct proof nonce once at the credential request boundary.
- Keep `verifyCNonce()` side-effect free so multi-proof and key-attestation flows can validate the same nonce during one request.
- Remove eager attestation nonce replay handling that used an incorrect TTL.
- Add regression coverage for single-use nonce consumption.

closes  https://github.com/adorsys/keycloak-oid4vc/issues/301